### PR TITLE
Remove public email address to prevent spam

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -15,7 +15,7 @@
 # in the templates via {{ site.myvariable }}.
 title: Nir Yechiel's Blog
 author: Nir Yechiel
-email: n.yechiel@gmail.com
+# email: n.yechiel@gmail.com # Removed to prevent spam - contact via social links
 description: >- # this means to ignore newlines until "baseurl:"
   Random thoughts on various aspects of computer networking.
 baseurl: "" # the subpath of your site, e.g. /blog


### PR DESCRIPTION
## Summary
Removed publicly visible email address from site configuration to reduce spam and improve privacy.

## Changes
- Commented out `email: n.yechiel@gmail.com` in `_config.yml`
- Added explanatory comment about spam prevention

## Why This Change?
Public email addresses on websites are frequently harvested by spam bots and added to spam lists. This is a privacy best practice for public-facing sites.

## Alternative Contact Methods
Users can still reach out via the configured social media links:
- Twitter: @nyechiel
- LinkedIn: nyechiel
- GitHub: @nyechiel

## Impact
- No functional impact on site
- Email field in site metadata will be empty
- Social links remain fully functional

🤖 Generated with [Claude Code](https://claude.com/claude-code)