### PR TITLE
Remove unused jekyll-mentions plugin

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -27,7 +27,6 @@ gem "minima", "~> 2.0"
 group :jekyll_plugins do
   gem "jekyll-feed", "~> 0.17"
   gem 'jekyll-seo-tag', "~> 2.8"
-  gem "jekyll-mentions", "~> 1.6"
   gem "webrick", "~> 1.8"
   gem "kramdown-parser-gfm", "~> 1.1"
 end


### PR DESCRIPTION
## Summary
Removed `jekyll-mentions` plugin which is not being used in the blog.

## Analysis
Searched all blog posts and found:
- ❌ No GitHub @mentions in use
- ❌ No `{% mention %}` tags in templates
- ✅ Only shell prompts like `cumulus@leaf1` (not actual mentions)

## Benefits

### 🔒 Security
Eliminates Dependabot security warnings for `activesupport`:
- Current: `activesupport 6.0.6.1` (vulnerable)
- Required: `activesupport >= 6.1.7.5` (secure)
- **Root cause:** `jekyll-mentions` → `html-pipeline` → `activesupport`

Removing this plugin breaks the dependency chain and eliminates the vulnerability.

### ⚡ Performance  
- Smaller dependency tree
- Faster build times
- Reduced potential attack surface

## Risk Assessment
**Low risk** - Plugin was never being used, so removing it has no functional impact.

## Testing
- No functional changes expected
- GitHub Pages will rebuild successfully
- All existing content will render identically

🤖 Generated with [Claude Code](https://claude.com/claude-code)