### PR TITLE
Fix invalid SRI hashes for security libraries

### DIFF
--- a/_includes/comments.html
+++ b/_includes/comments.html
@@ -1,8 +1,8 @@
 <script src="https://unpkg.com/showdown@2.1.0/dist/showdown.min.js"
-        integrity="sha384-/J0KYnlNsAqPt9dCAUkxvc4j0pkLl6KTqRmH4mcOc1Y6CqCpbGMTXmnXDV9NgkaW"
+        integrity="sha384-GP2+CwBlakZSDJUr+E4JvbxpM75i1i8+RKkieQxzuyDZLG+5105E1OfHIjzcXyWH"
         crossorigin="anonymous"></script>
 <script src="https://unpkg.com/dompurify@3.0.6/dist/purify.min.js"
-        integrity="sha384-/6jxv8qRU6F5tL3SzpLkT7LXFdLb/iLqjQqCqJdLZ5jDXNzw7xPjC9U+QRZ9QQJ"
+        integrity="sha384-cwS6YdhLI7XS60eoDiC+egV0qHp8zI+Cms46R0nbn8JrmoAzV9uFL60etMZhAnSu"
         crossorigin="anonymous"></script>
 <script>
 const GH_API_URL = 'https://api.github.com/repos/nyechiel/nyechiel.github.io/issues/{{ page.comments_id }}/comments';


### PR DESCRIPTION
## Summary
- Fixed invalid SRI hash for DOMPurify that was preventing proper integrity verification
- Updated Showdown SRI hash to use correct value computed from actual library file
- Both hashes are now properly computed SHA-384 hashes that browsers can verify

## Background
The previous SRI hashes were placeholders that didn't match the actual library files. This defeated the purpose of Subresource Integrity protection, which is meant to ensure that CDN-served scripts haven't been tampered with.

## Changes
- `showdown@2.1.0`: Updated to `sha384-GP2+CwBlakZSDJUr+E4JvbxpM75i1i8+RKkieQxzuyDZLG+5105E1OfHIjzcXyWH`
- `dompurify@3.0.6`: Updated to `sha384-cwS6YdhLI7XS60eoDiC+egV0qHp8zI+Cms46R0nbn8JrmoAzV9uFL60etMZhAnSu`

## Test plan
- [x] Generated hashes using `curl | sha384sum | xxd -r -p | base64`
- [x] Verify PR tests pass (build, markdown-lint, security-scan)
- [ ] Confirm comment system still works on a test post after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)