### PR TITLE
Add internal link checking to PR tests

### DIFF
--- a/.github/workflows/pr-tests.yml
+++ b/.github/workflows/pr-tests.yml
@@ -36,6 +36,16 @@ jobs:
         fi
         echo "✅ Site built successfully"
 
+    - name: Install html-proofer
+      run: gem install html-proofer
+
+    - name: Check links
+      run: |
+        htmlproofer _site \
+          --disable-external \
+          --ignore-urls "/^\/2[0-9]{3}\//,/^https:\/\/nyechiel\.com\/2[0-9]{3}\//,/fontawesome/" \
+          --no-enforce-https
+
   markdown-lint:
     runs-on: ubuntu-latest
 


### PR DESCRIPTION
## Summary
- Add internal link checking to the `build-and-test` job using `html-proofer`
- Installs `html-proofer` standalone via `gem install` (no Gemfile changes)
- Checks internal links only (external disabled to avoid flaky CI)
- Ignores redirect page URLs and the Font Awesome CSS reference

## Test plan
- [x] Verify the PR Tests workflow passes with the new link check step

🤖 Generated with [Claude Code](https://claude.com/claude-code)