### PR TITLE
Add podcasts page

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -25,6 +25,7 @@ show_excerpts: true
 header_pages:
   - index.md
   - blog/index.md
+  - podcasts.md
   - about.md
 twitter_username: nyechiel
 github_username: nyechiel

--- a/index.md
+++ b/index.md
@@ -12,6 +12,10 @@ Check out my [blog](/blog/) for thoughts on product engineering, technology, peo
 
 [View All Posts →](/blog/)
 
+## Podcasts
+
+Check out [podcast episodes](/podcasts/) I have been featured in.
+
 ## About
 
 Learn more [about me](/about/) and this site.

--- a/podcasts.md
+++ b/podcasts.md
@@ -1,0 +1,16 @@
+---
+layout: page
+title: Podcasts
+description: "Podcast episodes featuring Nir Yechiel, covering topics like networking, hybrid cloud, OpenStack, and open source."
+permalink: /podcasts/
+---
+
+Podcast episodes I have been featured in.
+
+- **Talking Open: Networking** (December 2022, Hebrew)
+  A conversation about networking in a hybrid cloud environment.
+  [Podbean](https://talkingopen.podbean.com/e/%D7%9E%D7%93%D7%91%D7%A8%D7%99%D7%9D-%D7%A4%D7%AA%D7%95%D7%97-%D7%A2%D7%9D-%D7%A0%D7%99%D7%A8-%D7%99%D7%97%D7%99%D7%90%D7%9C/) &#124; [YouTube](https://www.youtube.com/watch?v=hEKJqJ50KVU) &#124; [Spotify](https://open.spotify.com/episode/0EGpZBVwbsmuZZl4EImCtp)
+
+- **CloudTalk: Building an OpenStack-based Private Cloud** (March 2018, Hebrew)
+  A conversation about the open source model and managing a private cloud based on OpenStack.
+  [Apple Podcasts](https://podcasts.apple.com/us/podcast/%D7%A4%D7%A8%D7%A7-18-%D7%A0%D7%99%D7%94%D7%95%D7%9C-%D7%A2%D7%A0%D7%9F-%D7%A4%D7%A8%D7%98%D7%99-%D7%9E%D7%91%D7%95%D7%A1%D7%A1-openstack/id1367690895?i=1000408103962) &#124; [Podbay](https://podbay.fm/p/cloudtalk/e/1521469837)


### PR DESCRIPTION
## Summary
- Add a dedicated `/podcasts/` page listing podcast episode appearances
- Two episodes: Talking Open (2022) and CloudTalk (2018), both in Hebrew
- Add "Podcasts" to the site navigation between Blog and About
- Link to the podcasts page from the homepage
- Include meta description for SEO

## Test plan
- [x] Verify `/podcasts/` page renders correctly with both episodes and links
- [x] Verify "Podcasts" appears in the site navigation
- [x] Verify the homepage links to the podcasts page
- [x] Verify link checker passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)