### PR TITLE
Update Blog with Integrity text on about page

### DIFF
--- a/about.md
+++ b/about.md
@@ -7,7 +7,7 @@ permalink: /about/
 This blog is written and maintained by Nir Yechiel. It started as a way to document thoughts on computer networking, but has grown to cover broader topics including product engineering and technology. The site is developed with Jekyll and hosted on GitHub Pages. Looking for slides from a talk I gave? [Check my presentation slides on GitHub](https://github.com/nyechiel/presentation-slides).
 
 ## Blog with Integrity
-I believe strongly in blogging with integrity. I have signed the [pledge](http://www.blogwithintegrity.com/), and stand behind everything it says.
+I only write about things I believe in. I won't promote something I wouldn't use myself, and I don't take sponsored posts. If I share it here, it's because I stand behind it.
 
 ## Disclaimer
 The views in this blog are my own and do not necessarily reflect those of my employer or anyone else. For any official statements on matters in this blog, you should contact the appropriate marketing or media contact in the respective organization(s). The photos on my blog are either taken by me or in the public domain with full rights granted for non-commercial use.


### PR DESCRIPTION
## Summary
- Replace the old pledge link text with a clearer personal statement about editorial integrity

🤖 Generated with [Claude Code](https://claude.com/claude-code)