### PR TITLE
Rewrite about page

### DIFF
--- a/about.md
+++ b/about.md
@@ -4,10 +4,35 @@ title: About
 permalink: /about/
 ---
 
-This blog is written and maintained by Nir Yechiel. It started as a way to document thoughts on computer networking, but has grown to cover broader topics including product engineering and technology. The site is developed with Jekyll and hosted on GitHub Pages. Looking for slides from a talk I gave? [Check my presentation slides on GitHub](https://github.com/nyechiel/presentation-slides).
+Hi, I'm Nir Yechiel. I'm a product manager at [Red Hat](https://www.redhat.com/), focused on the intersection of AI and enterprise software.
 
-## Blog with Integrity
+I started my career in computer networking, designing and operating networks across enterprise, data center, and service provider environments. That hands-on background led me to product management, where I spent several years bringing open source infrastructure products to market - first Red Hat Virtualization, then OpenStack networking, and later OpenShift. Along the way I worked closely with upstream communities including oVirt, OpenStack, Kubernetes, Open vSwitch, OpenDaylight, OPNFV, and others.
+
+In 2019 I joined Facebook (now Meta) to work on connectivity infrastructure, before returning to Red Hat in engineering management. Over six years I grew from managing a single team to a director role overseeing application networking in OpenShift - including Submariner, Service Mesh (Istio, Envoy, Kiali), Kubernetes Gateway API and Service Interconnect (Skupper). In 2026 I transitioned back to product management, this time focused on AI.
+
+I care about building products that solve real problems, supporting the people I work with, and staying close to the technology. I'm a strong believer in open source and its ability to drive innovation.
+
+
+## Talks
+
+I've spoken at Red Hat Summit and other industry events on topics including OpenStack networking, SDN, NFV, and Kubernetes multi-cluster connectivity. [Slides are available on GitHub](https://github.com/nyechiel/presentation-slides).
+
+## Podcasts
+
+I've been featured in podcast episodes covering networking, hybrid cloud, and open source. See the full list on my [Podcasts](/podcasts/) page.
+
+## This Blog
+
+This blog started as a way to document thoughts on computer networking, and has grown to cover product management, AI, technology, and people. The site is built with [Jekyll](https://jekyllrb.com/) and hosted on [GitHub Pages](https://pages.github.com/).
+
 I only write about things I believe in. I won't promote something I wouldn't use myself, and I don't take sponsored posts. If I share it here, it's because I stand behind it.
 
 ## Disclaimer
-The views in this blog are my own and do not necessarily reflect those of my employer or anyone else. For any official statements on matters in this blog, you should contact the appropriate marketing or media contact in the respective organization(s). The photos on my blog are either taken by me or in the public domain with full rights granted for non-commercial use.
+
+The views in this blog are my own and do not necessarily reflect those of my employer or anyone else. For any official statements on matters in this blog, you should contact the appropriate marketing or media contact in the respective organization(s).
+
+## Connect
+
+- [GitHub](https://github.com/nyechiel)
+- [LinkedIn](https://www.linkedin.com/in/nyechiel)
+- [X (Twitter)](https://twitter.com/nyechiel)


### PR DESCRIPTION
## Summary
- Rewrote the about page with a fuller bio covering career arc from networking through PM, Meta, engineering management (up to director), and back to PM for AI
- Added sections for Talks, Podcasts, This Blog, Disclaimer, and Connect
- Kept the "blog with integrity" pledge and disclaimer

🤖 Generated with [Claude Code](https://claude.com/claude-code)