### PR TITLE
Visual refresh: Inter font, refined typography, and colors

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -2,6 +2,9 @@
   <meta charset="utf-8">
   <meta http-equiv="X-UA-Compatible" content="IE=edge">
   <meta name="viewport" content="width=device-width, initial-scale=1">
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="{{ "/assets/main.css" | relative_url }}">
   <link rel="stylesheet" href="{{ "/assets/fontawesome/css/all.css" | relative_url }}">
   {%- feed_meta -%}

--- a/about.md
+++ b/about.md
@@ -4,7 +4,7 @@ title: About
 permalink: /about/
 ---
 
-Hi, I'm Nir Yechiel. I'm a product manager at [Red Hat](https://www.redhat.com/), focused on the intersection of AI and enterprise software.
+I'm a product manager at [Red Hat](https://www.redhat.com/), focused on the intersection of AI and enterprise software.
 
 I started my career in computer networking, designing and operating networks across enterprise, data center, and service provider environments. That hands-on background led me to product management, where I spent several years bringing open source infrastructure products to market - first Red Hat Virtualization, then OpenStack networking, and later OpenShift. Along the way I worked closely with upstream communities including oVirt, OpenStack, Kubernetes, Open vSwitch, OpenDaylight, OPNFV, and others.
 

--- a/assets/main.scss
+++ b/assets/main.scss
@@ -1,0 +1,489 @@
+---
+---
+
+$base-font-family: "Inter", -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
+$base-font-size: 17px;
+$base-line-height: 1.7;
+$base-font-weight: 400;
+
+$text-color: #2d3436;
+$background-color: #fafafa;
+$brand-color: #0984e3;
+
+$grey-color: #636e72;
+$grey-color-light: #dfe6e9;
+$grey-color-dark: #2d3436;
+
+$content-width: 740px;
+$spacing-unit: 32px;
+
+@import "minima";
+
+// ————————————————————————————————————
+// Typography refinements
+// ————————————————————————————————————
+
+h1, h2, h3, h4, h5, h6 {
+  font-weight: 600;
+  color: #1a1a2e;
+  letter-spacing: -0.02em;
+}
+
+h2 {
+  margin-top: $spacing-unit * 1.5;
+}
+
+p, li {
+  letter-spacing: 0.005em;
+}
+
+// ————————————————————————————————————
+// Links
+// ————————————————————————————————————
+
+a {
+  text-decoration-color: rgba($brand-color, 0.3);
+  text-underline-offset: 2px;
+  transition: color 0.15s ease, text-decoration-color 0.15s ease;
+
+  &:hover {
+    color: darken($brand-color, 10%);
+    text-decoration: underline;
+    text-decoration-color: $brand-color;
+  }
+
+  &:visited {
+    color: darken($brand-color, 8%);
+  }
+}
+
+// ————————————————————————————————————
+// Header
+// ————————————————————————————————————
+
+.site-header {
+  border-top: 3px solid $brand-color;
+  border-bottom: 1px solid $grey-color-light;
+  background: #fff;
+}
+
+.site-title {
+  font-weight: 600;
+  letter-spacing: -0.5px;
+
+  &,
+  &:visited {
+    color: $text-color;
+  }
+}
+
+.site-nav .page-link {
+  font-size: 15px;
+  font-weight: 500;
+  color: $grey-color;
+  transition: color 0.15s ease;
+
+  &:hover {
+    color: $text-color;
+    text-decoration: none;
+  }
+}
+
+// ————————————————————————————————————
+// Post list (blog index)
+// ————————————————————————————————————
+
+.post-list {
+  > li {
+    padding-bottom: $spacing-unit;
+    border-bottom: 1px solid $grey-color-light;
+    margin-bottom: $spacing-unit;
+
+    &:last-child {
+      border-bottom: none;
+    }
+  }
+}
+
+.post-meta {
+  font-size: 14px;
+  color: $grey-color;
+  font-weight: 500;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+}
+
+.post-link {
+  font-weight: 600;
+  color: $text-color;
+  text-decoration: none;
+  transition: color 0.15s ease;
+
+  &:hover {
+    color: $brand-color;
+    text-decoration: none;
+  }
+
+  &:visited {
+    color: $text-color;
+  }
+}
+
+.post-list p {
+  color: $grey-color;
+  margin-top: 6px;
+  font-size: 15px;
+  line-height: 1.6;
+}
+
+// ————————————————————————————————————
+// Post content
+// ————————————————————————————————————
+
+.post-title {
+  font-weight: 700;
+  color: #1a1a2e;
+  line-height: 1.15;
+  margin-bottom: 8px;
+}
+
+.post-content {
+  font-size: 17px;
+  line-height: 1.75;
+
+  p {
+    margin-bottom: $spacing-unit * 0.75;
+  }
+
+  img {
+    border-radius: 6px;
+    margin: $spacing-unit * 0.5 0;
+  }
+}
+
+// ————————————————————————————————————
+// Blockquotes
+// ————————————————————————————————————
+
+blockquote {
+  border-left: 3px solid $brand-color;
+  background: rgba($brand-color, 0.04);
+  padding: $spacing-unit * 0.5 $spacing-unit * 0.75;
+  border-radius: 0 6px 6px 0;
+  font-style: italic;
+  color: $grey-color-dark;
+  letter-spacing: 0;
+
+  > :last-child {
+    margin-bottom: 0;
+  }
+}
+
+// ————————————————————————————————————
+// Code
+// ————————————————————————————————————
+
+pre, code {
+  background-color: #f1f3f5;
+  border: 1px solid #e9ecef;
+  border-radius: 4px;
+  font-size: 14px;
+}
+
+pre {
+  padding: $spacing-unit * 0.5 $spacing-unit * 0.6;
+  border-radius: 6px;
+
+  > code {
+    border: 0;
+    background: transparent;
+  }
+}
+
+code {
+  padding: 2px 6px;
+}
+
+// ————————————————————————————————————
+// Tables
+// ————————————————————————————————————
+
+table {
+  color: $text-color;
+  border: 1px solid $grey-color-light;
+  border-radius: 6px;
+
+  th {
+    background-color: #f1f3f5;
+    font-weight: 600;
+    border-color: $grey-color-light;
+  }
+
+  td {
+    border-color: $grey-color-light;
+  }
+
+  tr:nth-child(even) {
+    background-color: #f8f9fa;
+  }
+}
+
+// ————————————————————————————————————
+// Footer
+// ————————————————————————————————————
+
+.site-footer {
+  background: #fff;
+  border-top: 1px solid $grey-color-light;
+  padding: $spacing-unit * 1.2 0;
+}
+
+.footer-heading {
+  font-weight: 600;
+  font-size: 16px;
+  color: $text-color;
+}
+
+.footer-col-wrapper {
+  font-size: 14px;
+  color: $grey-color;
+}
+
+// ————————————————————————————————————
+// Home page
+// ————————————————————————————————————
+
+.home {
+  .page-heading {
+    font-weight: 700;
+    font-size: 28px;
+    color: #1a1a2e;
+    margin-bottom: $spacing-unit;
+  }
+}
+
+// ————————————————————————————————————
+// Page titles
+// ————————————————————————————————————
+
+.page-content {
+  padding: $spacing-unit * 1.5 0;
+}
+
+// ————————————————————————————————————
+// Comments section
+// ————————————————————————————————————
+
+.github-comments {
+  margin-top: $spacing-unit;
+
+  h2 {
+    font-size: 20px;
+    margin-bottom: $spacing-unit * 0.5;
+  }
+}
+
+// ————————————————————————————————————
+// Selection color
+// ————————————————————————————————————
+
+::selection {
+  background: rgba($brand-color, 0.15);
+}
+
+// ————————————————————————————————————
+// Horizontal rule
+// ————————————————————————————————————
+
+hr {
+  border: none;
+  border-top: 1px solid $grey-color-light;
+  margin: $spacing-unit 0;
+}
+
+// ————————————————————————————————————
+// Social media list (footer)
+// ————————————————————————————————————
+
+.social-media-list {
+  a {
+    text-decoration: none;
+
+    &:hover {
+      text-decoration: none;
+    }
+  }
+}
+
+// ————————————————————————————————————
+// RSS subscribe link
+// ————————————————————————————————————
+
+.rss-subscribe {
+  font-size: 14px;
+  color: $grey-color;
+  margin-top: $spacing-unit * 0.5;
+}
+
+// ————————————————————————————————————
+// Tags
+// ————————————————————————————————————
+
+.post-tags {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+  list-style: none;
+  margin: 8px 0 0 0;
+  padding: 0;
+}
+
+.post-tag {
+  display: inline-block;
+  font-size: 12px;
+  font-weight: 500;
+  color: $brand-color;
+  background: rgba($brand-color, 0.08);
+  padding: 2px 10px;
+  border-radius: 12px;
+  letter-spacing: 0.01em;
+  white-space: nowrap;
+  transition: background 0.15s ease, color 0.15s ease;
+
+  &:hover {
+    background: rgba($brand-color, 0.15);
+    text-decoration: none;
+  }
+}
+
+.post-tag--link {
+  text-decoration: none;
+  cursor: pointer;
+
+  &:visited {
+    color: $brand-color;
+  }
+
+  &:hover {
+    color: darken($brand-color, 10%);
+    text-decoration: none;
+  }
+}
+
+.post-tag--active {
+  background: $brand-color;
+  color: #fff;
+
+  &:visited,
+  &:hover {
+    color: #fff;
+  }
+
+  .tag-count {
+    color: rgba(#fff, 0.7);
+  }
+}
+
+// ————————————————————————————————————
+// Tags page
+// ————————————————————————————————————
+
+.tags-cloud {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  margin-bottom: $spacing-unit * 1.5;
+  padding-bottom: $spacing-unit;
+  border-bottom: 1px solid $grey-color-light;
+}
+
+.tags-cloud .post-tag {
+  font-size: 13px;
+  padding: 4px 12px;
+}
+
+.tag-count {
+  font-size: 11px;
+  color: $grey-color;
+  margin-left: 2px;
+}
+
+.tag-group {
+  margin-bottom: $spacing-unit * 1.5;
+}
+
+.tag-group-heading {
+  font-size: 20px;
+  margin-top: 0;
+  padding-top: $spacing-unit * 0.5;
+}
+
+.tag-group .post-list > li {
+  margin-bottom: $spacing-unit * 0.5;
+  padding-bottom: 0;
+  border-bottom: none;
+}
+
+.tag-group .post-link {
+  font-size: 17px;
+}
+
+// ————————————————————————————————————
+// Mobile
+// ————————————————————————————————————
+
+@include media-query($on-palm) {
+  body {
+    font-size: 16px;
+  }
+
+  .post-title {
+    font-size: 26px;
+    line-height: 1.2;
+  }
+
+  .post-content {
+    font-size: 16px;
+    line-height: 1.7;
+
+    h2 {
+      font-size: 22px;
+    }
+
+    h3 {
+      font-size: 19px;
+    }
+  }
+
+  .post-link {
+    font-size: 20px;
+    line-height: 1.3;
+  }
+
+  blockquote {
+    padding: $spacing-unit * 0.4 $spacing-unit * 0.5;
+    font-size: 16px;
+  }
+
+  pre {
+    padding: $spacing-unit * 0.4;
+    font-size: 13px;
+  }
+
+  .page-content {
+    padding: $spacing-unit 0;
+  }
+
+  .home .page-heading {
+    font-size: 24px;
+  }
+
+  .post-tags {
+    gap: 5px;
+  }
+
+  .post-tag {
+    font-size: 11px;
+    padding: 2px 8px;
+  }
+}

--- a/index.md
+++ b/index.md
@@ -4,7 +4,9 @@ title: Home
 description: "Nir Yechiel's personal website — writing about product engineering, technology, and people."
 ---
 
-Hi, I'm Nir Yechiel. I write about product engineering, technology, and people.
+Hi, I'm Nir Yechiel.
+
+Currently a Product Manager at Red Hat, working on AI-powered systems for the enterprise. Previously led engineering teams on OpenShift Networking (Submariner, Service Mesh, Ingress/DNS, Gateway API, Service Interconnect) and held various Engineering and Product roles across Red Hat, Facebook (Meta), and Cisco.
 
 ## Latest Posts
 


### PR DESCRIPTION
## Summary
- Switch body font to Inter (loaded from Google Fonts) with improved sizing (17px/1.7 line-height)
- Soften color palette: warmer text (#2d3436), blue accent (#0984e3), off-white background
- Refine header, footer, post list, blockquotes, code blocks, and table styling
- Add mobile-responsive overrides at the 600px breakpoint
- Update homepage intro text and remove redundant greeting from about page

## Test plan
- [ ] Verify site renders correctly at desktop and mobile widths
- [ ] Check blog listing, individual posts, about page, and podcasts page
- [ ] Confirm Inter font loads (check Network tab)
- [ ] Verify no visual regressions in code blocks, blockquotes, images, or tables

Co-authored with [Claude Code](https://claude.com/claude-code)