### PR TITLE
Add clickable tag pills and filterable tags page

### DIFF
--- a/_layouts/home.html
+++ b/_layouts/home.html
@@ -1,0 +1,41 @@
+---
+layout: default
+---
+
+<div class="home">
+  {%- if page.title -%}
+    <h1 class="page-heading">{{ page.title }}</h1>
+  {%- endif -%}
+
+  {{ content }}
+
+  {%- if site.posts.size > 0 -%}
+    <h2 class="post-list-heading">{{ page.list_title | default: "Posts" }}</h2>
+    <ul class="post-list">
+      {%- for post in site.posts -%}
+      <li>
+        {%- assign date_format = site.minima.date_format | default: "%b %-d, %Y" -%}
+        <span class="post-meta">{{ post.date | date: date_format }}</span>
+        <h3>
+          <a class="post-link" href="{{ post.url | relative_url }}">
+            {{ post.title | escape }}
+          </a>
+        </h3>
+        {%- if site.show_excerpts -%}
+          {{ post.excerpt }}
+        {%- endif -%}
+        {%- if post.tags.size > 0 -%}
+          <ul class="post-tags">
+            {%- for tag in post.tags -%}
+              <li><a class="post-tag post-tag--link" href="{{ "/tags/" | relative_url }}#{{ tag | slugify }}">{{ tag | escape }}</a></li>
+            {%- endfor -%}
+          </ul>
+        {%- endif -%}
+      </li>
+      {%- endfor -%}
+    </ul>
+
+    <p class="rss-subscribe">subscribe <a href="{{ "/feed.xml" | relative_url }}">via RSS</a></p>
+  {%- endif -%}
+
+</div>

--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -25,6 +25,13 @@ layout: default
             {%- if forloop.last == false %}, {% endif -%}
         {% endfor %}
       {%- endif -%}</p>
+    {%- if page.tags.size > 0 -%}
+      <ul class="post-tags">
+        {%- for tag in page.tags -%}
+          <li><a class="post-tag post-tag--link" href="{{ "/tags/" | relative_url }}#{{ tag | slugify }}">{{ tag | escape }}</a></li>
+        {%- endfor -%}
+      </ul>
+    {%- endif -%}
   </header>
 
   <div class="post-content e-content" itemprop="articleBody">
@@ -33,7 +40,6 @@ layout: default
   {% if page.comments_id %}
 	{% include comments.html %}
 	{% endif %}
-</section>
   <a class="u-url" href="{{ page.url | relative_url }}" hidden></a>
 </article>
 

--- a/tags.html
+++ b/tags.html
@@ -1,0 +1,86 @@
+---
+layout: page
+title: Tags
+permalink: /tags/
+---
+
+<div class="tags-page">
+  {%- assign sorted_tags = site.tags | sort -%}
+  <div class="tags-cloud">
+    <a class="post-tag post-tag--link post-tag--all" href="#" data-show-all>All</a>
+    {%- for tag in sorted_tags -%}
+      <a class="post-tag post-tag--link" href="#{{ tag[0] | slugify }}">{{ tag[0] | escape }} <span class="tag-count">{{ tag[1].size }}</span></a>
+    {%- endfor -%}
+  </div>
+
+  {%- for tag in sorted_tags -%}
+    <div class="tag-group" id="{{ tag[0] | slugify }}">
+      <h2 class="tag-group-heading">{{ tag[0] | escape }}</h2>
+      <ul class="post-list">
+        {%- assign date_format = site.minima.date_format | default: "%b %-d, %Y" -%}
+        {%- for post in tag[1] -%}
+          <li>
+            <span class="post-meta">{{ post.date | date: date_format }}</span>
+            <h3>
+              <a class="post-link" href="{{ post.url | relative_url }}">{{ post.title | escape }}</a>
+            </h3>
+          </li>
+        {%- endfor -%}
+      </ul>
+    </div>
+  {%- endfor -%}
+</div>
+
+<script>
+(function() {
+  var groups = document.querySelectorAll('.tag-group');
+  var pills = document.querySelectorAll('.tags-cloud .post-tag--link');
+  var allBtn = document.querySelector('[data-show-all]');
+
+  function filterByHash() {
+    var hash = window.location.hash.slice(1);
+    if (!hash) {
+      showAll();
+      return;
+    }
+    var found = false;
+    groups.forEach(function(g) {
+      if (g.id === hash) {
+        g.style.display = '';
+        found = true;
+      } else {
+        g.style.display = 'none';
+      }
+    });
+    if (!found) {
+      showAll();
+      return;
+    }
+    pills.forEach(function(p) {
+      if (p.getAttribute('href') === '#' + hash) {
+        p.classList.add('post-tag--active');
+      } else {
+        p.classList.remove('post-tag--active');
+      }
+    });
+    if (allBtn) allBtn.classList.remove('post-tag--active');
+  }
+
+  function showAll() {
+    groups.forEach(function(g) { g.style.display = ''; });
+    pills.forEach(function(p) { p.classList.remove('post-tag--active'); });
+    if (allBtn) allBtn.classList.add('post-tag--active');
+  }
+
+  if (allBtn) {
+    allBtn.addEventListener('click', function(e) {
+      e.preventDefault();
+      history.replaceState(null, '', window.location.pathname);
+      showAll();
+    });
+  }
+
+  window.addEventListener('hashchange', filterByHash);
+  filterByHash();
+})();
+</script>


### PR DESCRIPTION
## Summary
- Show post tags as clickable pill badges on blog listing and individual post pages
- Add /tags/ page with tag cloud and client-side JS filtering (shows only the selected tag's posts)
- Custom home layout overrides minima to include tag pills in the post list
- Fix pre-existing orphaned `</section>` tag in post layout
- HTML-escape all tag output in templates (XSS hardening)

**Depends on:** #76 (visual refresh, which includes the tag pill CSS)

## Test plan
- [ ] Click a tag pill from any post — should navigate to /tags/#tag-name showing only that tag's posts
- [ ] Click "All" on the tags page — should show all tag groups
- [ ] Click between tags in the cloud — should switch filters smoothly
- [ ] Verify tags appear on blog listing (/blog/) and individual post pages
- [ ] Test with JavaScript disabled — all tags should be visible (graceful fallback)
- [ ] Verify HTML validates (no orphaned tags)

Co-authored with [Claude Code](https://claude.com/claude-code)