### PR TITLE
Clean up post tags for consistency

### DIFF
--- a/_posts/2014-09-16-whats-coming-in-openstack-networking-for-juno-release.md
+++ b/_posts/2014-09-16-whats-coming-in-openstack-networking-for-juno-release.md
@@ -5,6 +5,7 @@ date: 2014-09-16 21:01:29.000000000 +03:00
 categories:
 - Blog
 tags:
+- Neutron
 - OpenStack
 comments_id: 3
 permalink: "/blog/2014/09/16/whats-coming-in-openstack-networking-for-juno-release/"

--- a/_posts/2016-07-07-networking-sessions-in-red-hat-summit-2016.md
+++ b/_posts/2016-07-07-networking-sessions-in-red-hat-summit-2016.md
@@ -7,13 +7,13 @@ categories:
 - Talks
 tags:
 - Ansible
-- Cisco
 - Linux
 - NFV
 - OpenStack
 - Red Hat
-- RHEL
+- Red Hat Summit
 - SDN
+- Talks
 - Virtualization
 comments_id: 18
 permalink: "/blog/2016/07/07/networking-sessions-in-red-hat-summit-2016/"

--- a/_posts/2019-04-23-a-new-beginning.md
+++ b/_posts/2019-04-23-a-new-beginning.md
@@ -4,7 +4,10 @@ title: A New Beginning
 date: 2019-04-23 10:04:42.000000000 +03:00
 categories:
 - Blog
-tags: []
+tags:
+- Red Hat
+- Career
+- Product Management
 comments_id: 21
 permalink: "/blog/2019/04/23/a-new-beginning/"
 redirect_from: "/2019/04/23/a-new-beginning/"

--- a/_posts/2020-04-12-hello-again-red-hat.md
+++ b/_posts/2020-04-12-hello-again-red-hat.md
@@ -5,7 +5,9 @@ date: 2020-04-12 13:24:56.000000000 +03:00
 categories:
 - Blog
 tags:
+- Career
 - Kubernetes
+- Management
 - OpenShift
 - Red Hat
 - Submariner

--- a/_posts/2020-04-13-red-hat-summit-2020-networking-sessions-you-dont-want-to-miss.md
+++ b/_posts/2020-04-13-red-hat-summit-2020-networking-sessions-you-dont-want-to-miss.md
@@ -11,6 +11,7 @@ tags:
 - Open Source
 - Red Hat
 - Red Hat Summit
+- Talks
 comments_id: 23
 permalink: "/blog/2020/04/13/red-hat-summit-2020-networking-sessions-you-dont-want-to-miss/"
 redirect_from: "/2020/04/13/red-hat-summit-2020-networking-sessions-you-dont-want-to-miss/"

--- a/_posts/2020-05-24-thoughts-on-mental-health-project-aristotle-and-maslows-hierarchy-of-needs.md
+++ b/_posts/2020-05-24-thoughts-on-mental-health-project-aristotle-and-maslows-hierarchy-of-needs.md
@@ -6,7 +6,8 @@ categories:
 - Blog
 tags:
 - COVID-19
-- Health
+- Management
+- People
 comments_id: 24
 permalink: "/blog/2020/05/24/thoughts-on-mental-health-project-aristotle-and-maslows-hierarchy-of-needs/"
 redirect_from: "/2020/05/24/thoughts-on-mental-health-project-aristotle-and-maslows-hierarchy-of-needs/"

--- a/_posts/2020-07-01-migrating-my-blog-from-wordpress-to-github-pages.md
+++ b/_posts/2020-07-01-migrating-my-blog-from-wordpress-to-github-pages.md
@@ -6,6 +6,7 @@ categories:
 - Blog
 tags:
 - GitHub Pages
+- Jekyll
 comments_id: 25
 permalink: "/blog/2020/07/01/migrating-my-blog-from-wordpress-to-github-pages/"
 redirect_from: "/2020/07/01/migrating-my-blog-from-wordpress-to-github-pages/"

--- a/_posts/2022-03-20-second-anniversary-at-red-hat .md
+++ b/_posts/2022-03-20-second-anniversary-at-red-hat .md
@@ -5,9 +5,11 @@ date: 2022-03-20 12:29:20.000000000 +03:00
 categories:
 - Blog
 tags:
+- Career
 - Kubernetes
-- Red Hat
 - Management
+- OpenShift
+- Red Hat
 comments_id: 27
 permalink: "/blog/2022/03/20/second-anniversary-at-red-hat/"
 redirect_from: "/2022/03/20/second-anniversary-at-red-hat/"


### PR DESCRIPTION
## Summary
- Add tags to "A New Beginning" post (was the only post with no tags)
- Add `Career` tag linking the 3 career reflection posts together
- Add `Talks` tag consistently to all 5 conference-related posts
- Replace one-off tags (`RHEL`, `Cisco`, `Health`) with more useful alternatives (`Red Hat Summit`, `Talks`, `People`, `Management`)
- Add missing `Neutron`, `OpenShift`, `Jekyll` tags where appropriate

**Independent of the visual refresh PRs** — can merge in any order.

## Test plan
- [ ] Verify site builds successfully
- [ ] Spot-check frontmatter in changed posts

Co-authored with [Claude Code](https://claude.com/claude-code)