### PR TITLE
Show latest 2 posts on home page

### DIFF
--- a/index.md
+++ b/index.md
@@ -10,7 +10,14 @@ I am a product manager at Red Hat, building agentic AI systems that help enterpr
 
 ## Latest Posts
 
-Check out my [blog](/blog/) for thoughts on product engineering, technology, people, and where they intersect.
+{% for post in site.posts limit:2 %}
+<small>{{ post.date | date: "%B %-d, %Y" }}</small>
+
+**[{{ post.title }}]({{ post.url }})**
+
+{{ post.excerpt | strip_html | truncatewords: 30 }}
+
+{% endfor %}
 
 [View All Posts →](/blog/)
 


### PR DESCRIPTION
## Summary
- Replace the static "Latest Posts" link on the home page with a dynamic listing of the 2 most recent posts
- Each post shows date, linked title, and a 30-word excerpt

## Test plan
- [x] Verify the home page renders the 2 most recent posts correctly
- [x] Check that post titles link to the correct URLs
- [x] Confirm the "View All Posts →" link still works

Co-authored with [Claude Code](https://claude.com/claude-code)