### PR TITLE
Add OG descriptions to published posts

### DIFF
--- a/_posts/2026-05-13-ai-operating-system-for-product-management.md
+++ b/_posts/2026-05-13-ai-operating-system-for-product-management.md
@@ -10,6 +10,7 @@ tags:
 - Claude Code
 - MCP
 - Red Hat
+description: "How I built an AI-powered workflow to handle the operational side of product management, using Claude Code and MCP integrations."
 comments_id: 70
 image:
   path: /assets/images/blog/ai-operating-system-for-product-management.jpg

--- a/_posts/2026-05-31-what-i-learned-in-my-first-30-days-back-in-product-management.md
+++ b/_posts/2026-05-31-what-i-learned-in-my-first-30-days-back-in-product-management.md
@@ -10,6 +10,7 @@ tags:
 - AI
 - Red Hat
 - Leadership
+description: "Returning to product management after 6+ years of engineering leadership. What transferred, what didn't, and what surprised me."
 comments_id: 81
 permalink: "/blog/2026/05/31/what-i-learned-in-my-first-30-days-back-in-product-management/"
 redirect_from: "/2026/05/31/what-i-learned-in-my-first-30-days-back-in-product-management/"


### PR DESCRIPTION
Adds short `description` frontmatter to both published posts for optimal social media previews (110-160 chars).

Without this, `jekyll-seo-tag` auto-generates from the first paragraph, which was 317 chars - too long for OG previews.