### PR TITLE
Fix post link cursor behavior on long titles

### DIFF
--- a/assets/main.scss
+++ b/assets/main.scss
@@ -114,6 +114,7 @@ a {
 }
 
 .post-link {
+  display: inline;
   font-weight: 600;
   color: $text-color;
   text-decoration: none;


### PR DESCRIPTION
Overrides minima's `display: block` on `.post-link` with `display: inline`. The block display caused the link's clickable area to extend across the full container width, making the cursor flicker on multi-line titles in the blog index.