### PR TITLE
Fix hover color on visited post links

### DIFF
--- a/assets/main.scss
+++ b/assets/main.scss
@@ -120,13 +120,13 @@ a {
   text-decoration: none;
   transition: color 0.15s ease;
 
+  &:visited {
+    color: $text-color;
+  }
+
   &:hover {
     color: $brand-color;
     text-decoration: none;
-  }
-
-  &:visited {
-    color: $text-color;
   }
 }
 


### PR DESCRIPTION
## Summary

- Reorder `.post-link` CSS pseudo-classes to follow LVHA (Link, Visited, Hover, Active) order
- Previously `:visited` was declared after `:hover` at the same specificity, so visited links stayed black on hover instead of changing to blue
- Only affected posts the user had actually clicked (e.g., "I Built a Personal AI Operating System for Product Management")

## Test plan

- [ ] Open /blog/ in Chrome and Firefox
- [ ] Click a post link, navigate back to /blog/
- [ ] Hover the visited post link — should change to blue (`#0984e3`)
- [ ] Hover an unvisited post link — should also change to blue
- [ ] Verify cursor is pointer on all post links

Co-authored with [Claude Code](https://claude.com/claude-code)