### PR TITLE
Fix excessive line spacing on multi-line post titles

### DIFF
--- a/assets/main.scss
+++ b/assets/main.scss
@@ -113,6 +113,10 @@ a {
   letter-spacing: 0.04em;
 }
 
+.post-list h3 {
+  line-height: 1.3;
+}
+
 .post-link {
   display: inline;
   font-weight: 600;


### PR DESCRIPTION
## Summary

- Set `line-height: 1.3` on `.post-list h3` to reduce vertical spacing when post titles wrap to multiple lines
- Fixes the tags page (visible on long titles like the SR-IOV posts) and the blog index

The base `line-height: 1.7` is great for body text but creates a noticeable gap between lines when headings wrap.