### PR TITLE
Add bundler ecosystem to Dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,3 +9,9 @@ updates:
         patterns:
           - "*"
     open-pull-requests-limit: 5
+
+  - package-ecosystem: "bundler"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5


### PR DESCRIPTION
## Summary
- Add `bundler` package ecosystem to Dependabot configuration
- Enables weekly automated dependency updates for Ruby gems, matching the existing GitHub Actions update cadence

## Test plan
- [ ] Verify Dependabot picks up the new config and starts checking for gem updates

Co-authored with [Claude Code](https://claude.com/claude-code)