### PR TITLE
Subtle visual polish for the homepage

### DIFF
--- a/_includes/header.html
+++ b/_includes/header.html
@@ -1,0 +1,33 @@
+<header class="site-header" role="banner">
+
+  <div class="wrapper">
+    {%- assign default_paths = site.pages | map: "path" -%}
+    {%- assign page_paths = site.header_pages | default: default_paths -%}
+    <a class="site-title" rel="author" href="{{ "/" | relative_url }}">{{ site.title | escape }}</a>
+
+    {%- if page_paths -%}
+      <nav class="site-nav">
+        <input type="checkbox" id="nav-trigger" class="nav-trigger" />
+        <label for="nav-trigger">
+          <span class="menu-icon">
+            <svg viewBox="0 0 18 15" width="18px" height="15px">
+              <path d="M18,1.484c0,0.82-0.665,1.484-1.484,1.484H1.484C0.665,2.969,0,2.304,0,1.484l0,0C0,0.665,0.665,0,1.484,0 h15.032C17.335,0,18,0.665,18,1.484L18,1.484z M18,7.516C18,8.335,17.335,9,16.516,9H1.484C0.665,9,0,8.335,0,7.516l0,0 c0-0.82,0.665-1.484,1.484-1.484h15.032C17.335,6.031,18,6.696,18,7.516L18,7.516z M18,13.516C18,14.335,17.335,15,16.516,15H1.484 C0.665,15,0,14.335,0,13.516l0,0c0-0.82,0.665-1.483,1.484-1.483h15.032C17.335,12.031,18,12.695,18,13.516L18,13.516z"/>
+            </svg>
+          </span>
+        </label>
+
+        <div class="trigger">
+          {%- for path in page_paths -%}
+            {%- assign my_page = site.pages | where: "path", path | first -%}
+            {%- if my_page.title -%}
+            {%- assign is_active = false -%}
+            {%- if page.url == my_page.url -%}{%- assign is_active = true -%}{%- endif -%}
+            {%- if my_page.url == "/blog/" and page.layout == "post" -%}{%- assign is_active = true -%}{%- endif -%}
+            <a class="page-link{% if is_active %} page-link--active{% endif %}" href="{{ my_page.url | relative_url }}">{{ my_page.title | escape }}</a>
+            {%- endif -%}
+          {%- endfor -%}
+        </div>
+      </nav>
+    {%- endif -%}
+  </div>
+</header>

--- a/_layouts/page.html
+++ b/_layouts/page.html
@@ -1,0 +1,15 @@
+---
+layout: default
+---
+<article class="post">
+
+  <header class="post-header">
+    {%- assign display_heading = page.heading | default: page.title -%}
+    <h1 class="post-title">{{ display_heading | escape }}</h1>
+  </header>
+
+  <div class="post-content">
+    {{ content }}
+  </div>
+
+</article>

--- a/assets/main.scss
+++ b/assets/main.scss
@@ -82,10 +82,21 @@ a {
   font-weight: 500;
   color: $grey-color;
   transition: color 0.15s ease;
+  padding-bottom: 4px;
+  border-bottom: 2px solid transparent;
 
   &:hover {
     color: $text-color;
     text-decoration: none;
+  }
+
+  &--active {
+    color: $brand-color;
+    border-bottom-color: $brand-color;
+
+    &:visited {
+      color: $brand-color;
+    }
   }
 }
 
@@ -282,12 +293,27 @@ table {
   }
 }
 
+.home-intro {
+  font-size: 19px;
+  line-height: 1.6;
+  padding-bottom: $spacing-unit * 1.2;
+  margin-bottom: $spacing-unit * 1.2;
+  border-bottom: 1px solid $grey-color-light;
+  color: $grey-color-dark;
+}
+
 // ————————————————————————————————————
 // Page titles
 // ————————————————————————————————————
 
+@keyframes page-enter {
+  from { opacity: 0; transform: translateY(8px); }
+  to { opacity: 1; transform: translateY(0); }
+}
+
 .page-content {
   padding: $spacing-unit * 1.5 0;
+  animation: page-enter 0.3s ease-out;
 }
 
 // ————————————————————————————————————

--- a/index.md
+++ b/index.md
@@ -1,12 +1,15 @@
 ---
 layout: page
 title: Home
+heading: "Hi, I'm Nir Yechiel."
 description: "Nir Yechiel's personal website — writing about product engineering, technology, and people."
 ---
 
-Hi, I'm Nir Yechiel.
+<div class="home-intro" markdown="1">
 
 I am a product manager at Red Hat, building agentic AI systems that reimagine how enterprise teams work. Previously led engineering teams on OpenShift Networking (Submariner, Service Mesh, Gateway API, Service Interconnect) and held engineering and product roles at Red Hat, Facebook (Meta), and Cisco.
+
+</div>
 
 ## Latest Posts
 


### PR DESCRIPTION
## Summary

- Active nav indicator: blue underline highlights the current page in the nav bar, including blog posts highlighting "Blog"
- Homepage intro styling: bottom divider separates the intro paragraph from the rest of the page
- Content fade-in: gentle 0.3s entrance animation on page load
- Greeting heading: page heading shows "Hi, I'm Nir Yechiel." instead of generic "Home" (nav link still says "Home")

## Files changed

- `assets/main.scss` - active nav CSS, `.home-intro` style, `page-enter` keyframes
- `index.md` - `heading` frontmatter field, `home-intro` wrapper div
- `_includes/header.html` (new) - overrides Minima header with active nav class logic
- `_layouts/page.html` (new) - overrides Minima page layout to support `heading` frontmatter

## Test plan

- [x] Verify homepage shows greeting heading and styled intro
- [x] Verify nav highlights correct page on each section
- [x] Verify blog posts highlight "Blog" in nav
- [x] Verify other pages (About, Podcasts, Tags) render normally
- [x] Check mobile responsive behavior