### PR TITLE
Remove rocket emoji from subscribe card

### DIFF
--- a/index.md
+++ b/index.md
@@ -25,7 +25,7 @@ I am a product manager at Red Hat, building agentic AI systems that reimagine ho
 [View All Posts →](/blog/)
 
 <div class="subscribe-card">
-  <p class="subscribe-card__text"><span class="subscribe-card__emoji">🚀</span> Like what you're reading? Get new posts straight to your inbox.</p>
+  <p class="subscribe-card__text">Like what you're reading? Get new posts straight to your inbox.</p>
   <form class="subscribe-card__form" action="https://api.follow.it/subscription-form/clBXWVBSbWJyanNERlN2VVRGTUNNdU1uSTF3b1hLRTBGcStIa282RFpaWEVpOVNuOXhieituSC9mVENiTUYzYmRXK25PVVRJM2ZGd3Z0NGVuc0N2R1gxa1lOK1A2S1FrRTEzVXhkZjBvb0xhN2d4L2QxOHpiZ0l1N3V3NmZyRmV8RDY2VzhJN1NzSTJsUyt4L0xTYlJiSkgvUnV6QVdjWjBTem9PQXRFNjBlYz0=/8" method="post">
     <input class="subscribe-card__input" type="email" name="email" placeholder="your@email.com" required />
     <button class="subscribe-card__button" type="submit">Subscribe</button>


### PR DESCRIPTION
## Summary
- Remove 🚀 emoji from the homepage subscribe card text

Co-authored with [Claude Code](https://claude.com/claude-code)