### PR TITLE
Add follow.it feed verification meta tag

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -12,4 +12,5 @@
     {%- include google-analytics.html -%}
   {%- endif -%}
   {% seo %}
+  <meta name="follow.it-verification-code" content="hP40yF01ZckKrsGaykxn"/>
 </head>


### PR DESCRIPTION
Adds the verification meta tag to `<head>` so follow.it can confirm site ownership. This enables the publisher dashboard (My Offered Feeds) with subscriber management, analytics, and delivery settings.

The tag can be removed after the one-time claim is complete.