### PR TITLE
Add Featured post hero card to homepage

### DIFF
--- a/_layouts/home.html
+++ b/_layouts/home.html
@@ -20,6 +20,9 @@ layout: default
           <a class="post-link" href="{{ post.url | relative_url }}">
             {{ post.title | escape }}
           </a>
+          {%- if post.featured -%}
+            <span class="featured-badge">Featured</span>
+          {%- endif -%}
         </h3>
         {%- if site.show_excerpts -%}
           {{ post.excerpt }}

--- a/_posts/2026-06-14-build-your-own-ai-augmented-workflow.md
+++ b/_posts/2026-06-14-build-your-own-ai-augmented-workflow.md
@@ -15,6 +15,7 @@ description: "A practical guide to building an AI-powered knowledge worker workf
 comments_id: 115
 permalink: "/blog/2026/06/14/build-your-own-ai-augmented-workflow/"
 redirect_from: "/2026/06/14/build-your-own-ai-augmented-workflow/"
+featured: true
 image:
   path: /assets/images/blog/ai-augmented-workflow.jpg
   alt: "A developer workspace with laptop, external monitor, and bookshelf"

--- a/assets/main.scss
+++ b/assets/main.scss
@@ -128,6 +128,20 @@ a {
   line-height: 1.3;
 }
 
+.featured-badge {
+  display: inline-block;
+  font-size: 11px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  color: $brand-color;
+  background: rgba($brand-color, 0.08);
+  padding: 2px 8px;
+  border-radius: 4px;
+  vertical-align: middle;
+  margin-left: 6px;
+}
+
 .post-link {
   display: inline;
   font-weight: 600;
@@ -300,6 +314,70 @@ table {
   margin-bottom: $spacing-unit * 1.2;
   border-bottom: 1px solid $grey-color-light;
   color: $grey-color-dark;
+}
+
+// ————————————————————————————————————
+// Featured card (homepage hero)
+// ————————————————————————————————————
+
+.featured-card {
+  border: 1px solid $grey-color-light;
+  border-radius: 8px;
+  overflow: hidden;
+  margin-bottom: $spacing-unit * 1.5;
+  background: #fff;
+  transition: box-shadow 0.15s ease;
+
+  &:hover {
+    box-shadow: 0 2px 12px rgba(0, 0, 0, 0.06);
+  }
+}
+
+.featured-card__image-link {
+  display: block;
+  text-decoration: none;
+}
+
+.featured-card__image {
+  width: 100%;
+  height: 220px;
+  object-fit: cover;
+  display: block;
+}
+
+.featured-card__body {
+  padding: $spacing-unit * 0.6 $spacing-unit * 0.75 $spacing-unit * 0.75;
+}
+
+.featured-card__label {
+  font-size: 12px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  color: $brand-color;
+}
+
+.featured-card__title {
+  font-size: 22px;
+  font-weight: 600;
+  line-height: 1.3;
+  margin: 4px 0 8px;
+
+  a {
+    color: $text-color;
+    text-decoration: none;
+    transition: color 0.15s ease;
+
+    &:visited { color: $text-color; }
+    &:hover { color: $brand-color; }
+  }
+}
+
+.featured-card__excerpt {
+  font-size: 15px;
+  line-height: 1.6;
+  color: $grey-color;
+  margin-bottom: 8px;
 }
 
 // ————————————————————————————————————
@@ -606,5 +684,22 @@ hr {
   .subscribe-card__input {
     width: 100%;
     max-width: 280px;
+  }
+
+  .featured-card__image {
+    height: 160px;
+  }
+
+  .featured-card__title {
+    font-size: 19px;
+  }
+
+  .featured-card__body {
+    padding: $spacing-unit * 0.5;
+  }
+
+  .featured-badge {
+    font-size: 10px;
+    padding: 1px 6px;
   }
 }

--- a/index.md
+++ b/index.md
@@ -11,9 +11,33 @@ I am a product manager at Red Hat, building agentic AI systems that reimagine ho
 
 </div>
 
+{% assign featured = site.posts | where: "featured", true | first %}
+{% if featured %}
+<div class="featured-card">
+  {% if featured.image %}
+  <a href="{{ featured.url }}" class="featured-card__image-link">
+    <img src="{{ featured.image.path | default: featured.image }}" alt="{{ featured.image.alt | default: featured.title }}" class="featured-card__image" />
+  </a>
+  {% endif %}
+  <div class="featured-card__body">
+    <span class="featured-card__label">Featured</span>
+    <h2 class="featured-card__title"><a href="{{ featured.url }}">{{ featured.title }}</a></h2>
+    <p class="featured-card__excerpt">{{ featured.excerpt | strip_html | truncatewords: 40 }}</p>
+    {% if featured.tags.size > 0 %}
+    <ul class="post-tags">
+      {% for tag in featured.tags %}
+      <li><a href="/tags/#{{ tag | slugify }}" class="post-tag post-tag--link">{{ tag }}</a></li>
+      {% endfor %}
+    </ul>
+    {% endif %}
+  </div>
+</div>
+{% endif %}
+
 ## Latest Posts
 
-{% for post in site.posts limit:3 %}
+{% assign post_limit = 3 %}{% if featured %}{% assign post_limit = 4 %}{% endif %}
+{% for post in site.posts limit:post_limit %}{% if featured and post.id == featured.id %}{% continue %}{% endif %}
 <small>{{ post.date | date: "%B %-d, %Y" }}</small>
 
 **[{{ post.title }}]({{ post.url }})**


### PR DESCRIPTION
## Summary

- Posts with `featured: true` in frontmatter render as a hero card (image + title + excerpt + tags) above Latest Posts on the homepage
- "Featured" badge appears next to the post title on the /blog/ listing page
- Only the most recent featured post is shown; it's excluded from Latest Posts to avoid duplication
- Mobile responsive with scaled image height, font sizes, and badge
- Graceful degradation: no featured posts = section doesn't render; no image = text-only card