### PR TITLE
Fix Search Console indexing issues

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -55,14 +55,13 @@ feed:
 twitter:
   card: summary_large_image
 
-# Exclude from processing.
-# The following items will not be processed, by default. Create a custom list
-# to override the default setting.
-# exclude:
-#   - Gemfile
-#   - Gemfile.lock
-#   - node_modules
-#   - vendor/bundle/
-#   - vendor/cache/
-#   - vendor/gems/
-#   - vendor/ruby/
+exclude:
+  - CLAUDE.md
+  - .claude
+  - Gemfile
+  - Gemfile.lock
+  - node_modules
+  - vendor/bundle/
+  - vendor/cache/
+  - vendor/gems/
+  - vendor/ruby/

--- a/_posts/2022-03-20-second-anniversary-at-red-hat .md
+++ b/_posts/2022-03-20-second-anniversary-at-red-hat .md
@@ -12,7 +12,6 @@ tags:
 - Red Hat
 comments_id: 27
 permalink: "/blog/2022/03/20/second-anniversary-at-red-hat/"
-redirect_from: "/2022/03/20/second-anniversary-at-red-hat/"
 ---
 Last month marked my second service anniversary since rejoining Red Hat. I feel like this is a good opportunity to reflect on the last two years and what I have been up to, both personally and professionally.
 

--- a/_posts/2026-05-31-what-i-learned-in-my-first-30-days-back-in-product-management.md
+++ b/_posts/2026-05-31-what-i-learned-in-my-first-30-days-back-in-product-management.md
@@ -13,7 +13,6 @@ tags:
 description: "Returning to product management after 6+ years of engineering leadership. What transferred, what didn't, and what surprised me."
 comments_id: 81
 permalink: "/blog/2026/05/31/what-i-learned-in-my-first-30-days-back-in-product-management/"
-redirect_from: "/2026/05/31/what-i-learned-in-my-first-30-days-back-in-product-management/"
 image:
   path: /assets/images/blog/what-i-learned-in-my-first-30-days-back-in-product-management.jpg
   alt: "Person holding a compass facing towards green pine trees"

--- a/_posts/2026-06-05-ai-brain-fry-is-real.md
+++ b/_posts/2026-06-05-ai-brain-fry-is-real.md
@@ -11,7 +11,6 @@ tags:
 description: "I built an AI-first system for my PM work. It works great. Now I have a different problem - and it has a name: AI brain fry."
 comments_id: 105
 permalink: "/blog/2026/06/05/ai-brain-fry-is-real/"
-redirect_from: "/2026/06/05/ai-brain-fry-is-real/"
 image:
   path: /assets/images/blog/ai-brain-fry-is-real.jpg
   alt: "Assorted colorful sticky notes"

--- a/_posts/2026-06-14-build-your-own-ai-augmented-workflow.md
+++ b/_posts/2026-06-14-build-your-own-ai-augmented-workflow.md
@@ -14,7 +14,6 @@ tags:
 description: "A practical guide to building an AI-powered knowledge worker workflow using Claude Code and MCP - with a template repo to get you started."
 comments_id: 115
 permalink: "/blog/2026/06/14/build-your-own-ai-augmented-workflow/"
-redirect_from: "/2026/06/14/build-your-own-ai-augmented-workflow/"
 featured: true
 image:
   path: /assets/images/blog/ai-augmented-workflow.jpg


### PR DESCRIPTION
## Summary
- Exclude CLAUDE.md and .claude/ from Jekyll build - was rendering publicly at /CLAUDE/ and polluting the sitemap
- Remove unnecessary `redirect_from` on 4 post-migration posts (2022, 2026) that never had old-style URLs - these created phantom redirect stub pages with noindex tags that inflated the "not indexed" count in Search Console
- Uncomment standard exclude list (Gemfile, vendor, node_modules)