### PR TITLE
Add star emoji to Featured label

### DIFF
--- a/_layouts/home.html
+++ b/_layouts/home.html
@@ -21,7 +21,7 @@ layout: default
             {{ post.title | escape }}
           </a>
           {%- if post.featured -%}
-            <span class="featured-badge">Featured</span>
+            <span class="featured-badge">⭐ Featured</span>
           {%- endif -%}
         </h3>
         {%- if site.show_excerpts -%}

--- a/index.md
+++ b/index.md
@@ -20,7 +20,7 @@ I am a product manager at Red Hat, building agentic AI systems that reimagine ho
   </a>
   {% endif %}
   <div class="featured-card__body">
-    <span class="featured-card__label">Featured</span>
+    <span class="featured-card__label">⭐ Featured</span>
     <h2 class="featured-card__title"><a href="{{ featured.url }}">{{ featured.title }}</a></h2>
     <p class="featured-card__excerpt">{{ featured.excerpt | strip_html | truncatewords: 40 }}</p>
     {% if featured.tags.size > 0 %}


### PR DESCRIPTION
## Summary
- Adds a ⭐ star emoji before the "Featured" label on the homepage featured card and the blog listing page badge

## Test plan
- [x] Verified locally with `bundle exec jekyll serve`
- [ ] Check homepage featured card shows "⭐ Featured"
- [ ] Check `/blog/` listing shows "⭐ Featured" badge on the featured post

Co-authored with [Claude Code](https://claude.com/claude-code)