### PR TITLE
Fix broken Claude Code URL in AI workflow post

### DIFF
--- a/_posts/2026-06-14-build-your-own-ai-augmented-workflow.md
+++ b/_posts/2026-06-14-build-your-own-ai-augmented-workflow.md
@@ -36,7 +36,7 @@ My own system is built around product management. But when people asked how to b
 
 ## The approach
 
-The system I built uses [Claude Code](https://claude.ai/claude-code) as the agent and [MCP (Model Context Protocol)](https://modelcontextprotocol.io/) to connect it to real tools - email, calendar, chat, task management, documents. The key idea is that the agent operates with the same tools you use, but with explicit boundaries and a human-as-approver model.
+The system I built uses [Claude Code](https://www.anthropic.com/claude-code) as the agent and [MCP (Model Context Protocol)](https://modelcontextprotocol.io/) to connect it to real tools - email, calendar, chat, task management, documents. The key idea is that the agent operates with the same tools you use, but with explicit boundaries and a human-as-approver model.
 
 Here's the architecture:
 


### PR DESCRIPTION
## Summary
- Fix Claude Code link in "The approach" section: `claude.ai/claude-code` -> `anthropic.com/claude-code`