### PR TITLE
Consolidate Management tag into Leadership

### DIFF
--- a/_posts/2020-04-12-hello-again-red-hat.md
+++ b/_posts/2020-04-12-hello-again-red-hat.md
@@ -7,7 +7,7 @@ categories:
 tags:
 - Career
 - Kubernetes
-- Management
+- Leadership
 - OpenShift
 - Red Hat
 - Submariner

--- a/_posts/2020-05-24-thoughts-on-mental-health-project-aristotle-and-maslows-hierarchy-of-needs.md
+++ b/_posts/2020-05-24-thoughts-on-mental-health-project-aristotle-and-maslows-hierarchy-of-needs.md
@@ -6,7 +6,7 @@ categories:
 - Blog
 tags:
 - COVID-19
-- Management
+- Leadership
 - People
 comments_id: 24
 permalink: "/blog/2020/05/24/thoughts-on-mental-health-project-aristotle-and-maslows-hierarchy-of-needs/"

--- a/_posts/2022-03-20-second-anniversary-at-red-hat .md
+++ b/_posts/2022-03-20-second-anniversary-at-red-hat .md
@@ -7,7 +7,7 @@ categories:
 tags:
 - Career
 - Kubernetes
-- Management
+- Leadership
 - OpenShift
 - Red Hat
 comments_id: 27


### PR DESCRIPTION
## Summary
- Rename the "Management" tag to "Leadership" across 3 posts for consistency
- "Leadership" already existed on 1 post (first-30-days-back-in-pm); now 4 posts total
- All affected posts discuss leadership roles and team dynamics - "Leadership" is the better label

**Posts updated:**
- `2020-04-12-hello-again-red-hat.md`
- `2020-05-24-thoughts-on-mental-health...md`
- `2022-03-20-second-anniversary-at-red-hat.md`

Co-authored with [Claude Code](https://claude.com/claude-code)