### PR TITLE
Add inline search to site navigation

### DIFF
--- a/_includes/header.html
+++ b/_includes/header.html
@@ -26,8 +26,128 @@
             <a class="page-link{% if is_active %} page-link--active{% endif %}" href="{{ my_page.url | relative_url }}">{{ my_page.title | escape }}</a>
             {%- endif -%}
           {%- endfor -%}
+          <span class="nav-search" id="nav-search">
+            <button type="button" class="nav-search__toggle" id="nav-search-toggle" aria-label="Search">
+              <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="11" cy="11" r="8"/><line x1="21" y1="21" x2="16.65" y2="16.65"/></svg>
+            </button>
+            <input type="text" id="nav-search-input" class="nav-search__input" placeholder="Search posts..." autocomplete="off">
+            <div id="nav-search-results" class="nav-search__results"></div>
+          </span>
         </div>
       </nav>
     {%- endif -%}
   </div>
 </header>
+
+<script>
+(function() {
+  var input = document.getElementById('nav-search-input');
+  var resultsEl = document.getElementById('nav-search-results');
+  var toggle = document.getElementById('nav-search-toggle');
+  var container = document.getElementById('nav-search');
+  if (!input || !resultsEl || !toggle || !container) return;
+
+  var posts = null;
+  var debounceTimer = null;
+  var isOpen = false;
+
+  var xhr = new XMLHttpRequest();
+  xhr.open('GET', '{{ "/search.json" | relative_url }}');
+  xhr.onload = function() {
+    if (xhr.status === 200) posts = JSON.parse(xhr.responseText);
+  };
+  xhr.send();
+
+  function openSearch() {
+    isOpen = true;
+    container.classList.add('nav-search--open');
+    input.focus();
+  }
+
+  function closeSearch() {
+    isOpen = false;
+    container.classList.remove('nav-search--open');
+    input.value = '';
+    resultsEl.innerHTML = '';
+    resultsEl.style.display = 'none';
+  }
+
+  toggle.addEventListener('click', function(e) {
+    e.stopPropagation();
+    if (isOpen) { closeSearch(); } else { openSearch(); }
+  });
+
+  input.addEventListener('input', function() {
+    clearTimeout(debounceTimer);
+    debounceTimer = setTimeout(doSearch, 200);
+  });
+
+  input.addEventListener('keydown', function(e) {
+    if (e.key === 'Escape') { closeSearch(); }
+  });
+
+  document.addEventListener('click', function(e) {
+    if (!e.target.closest('#nav-search')) { closeSearch(); }
+  });
+
+  function doSearch() {
+    var query = input.value.trim().toLowerCase();
+    if (!query || !posts) {
+      resultsEl.innerHTML = '';
+      resultsEl.style.display = 'none';
+      return;
+    }
+
+    var words = query.split(/\s+/).filter(function(w) { return w.length > 0; });
+    var scored = [];
+
+    for (var i = 0; i < posts.length; i++) {
+      var post = posts[i];
+      var score = 0;
+      var titleLower = post.title.toLowerCase();
+      var tagsLower = post.tags.map(function(t) { return t.toLowerCase(); });
+      var contentLower = post.content.toLowerCase();
+
+      for (var j = 0; j < words.length; j++) {
+        var w = words[j];
+        if (titleLower.indexOf(w) !== -1) score += 10;
+        for (var k = 0; k < tagsLower.length; k++) {
+          if (tagsLower[k].indexOf(w) !== -1) score += 5;
+        }
+        if (contentLower.indexOf(w) !== -1) score += 1;
+      }
+
+      if (score > 0) scored.push({ post: post, score: score });
+    }
+
+    scored.sort(function(a, b) { return b.score - a.score; });
+
+    if (scored.length === 0) {
+      resultsEl.innerHTML = '<div class="nav-search__empty">No results</div>';
+      resultsEl.style.display = 'block';
+      return;
+    }
+
+    var max = Math.min(scored.length, 6);
+    var html = '';
+    for (var i = 0; i < max; i++) {
+      var p = scored[i].post;
+      html += '<a class="nav-search__item" href="' + esc(p.url) + '">';
+      html += '<span class="nav-search__item-title">' + esc(p.title) + '</span>';
+      html += '<span class="nav-search__item-date">' + esc(p.date) + '</span>';
+      html += '</a>';
+    }
+    if (scored.length > max) {
+      html += '<a class="nav-search__more" href="/search/?q=' + encodeURIComponent(input.value.trim()) + '">' + scored.length + ' results - view all</a>';
+    }
+    resultsEl.innerHTML = html;
+    resultsEl.style.display = 'block';
+  }
+
+  function esc(text) {
+    var el = document.createElement('div');
+    el.appendChild(document.createTextNode(text));
+    return el.innerHTML;
+  }
+})();
+</script>

--- a/assets/main.scss
+++ b/assets/main.scss
@@ -618,6 +618,191 @@ hr {
 }
 
 // ————————————————————————————————————
+// Search (full page - /search/)
+// ————————————————————————————————————
+
+.search-input-wrap {
+  margin-bottom: $spacing-unit;
+}
+
+.search-input {
+  font-family: $base-font-family;
+  font-size: 17px;
+  width: 100%;
+  padding: 10px 14px;
+  border: 1px solid $grey-color-light;
+  border-radius: 6px;
+  background: #fff;
+  color: $text-color;
+  outline: none;
+  transition: border-color 0.15s ease, box-shadow 0.15s ease;
+
+  &:focus {
+    border-color: $brand-color;
+    box-shadow: 0 0 0 3px rgba($brand-color, 0.1);
+  }
+
+  &::placeholder {
+    color: $grey-color;
+  }
+}
+
+.search-results .post-list > li {
+  padding-bottom: $spacing-unit * 0.75;
+  margin-bottom: $spacing-unit * 0.75;
+}
+
+.search-message {
+  font-size: 15px;
+  color: $grey-color;
+  margin-bottom: $spacing-unit * 0.5;
+}
+
+// ————————————————————————————————————
+// Search (inline in nav)
+// ————————————————————————————————————
+
+.nav-search {
+  position: relative;
+  display: inline;
+}
+
+.nav-search__toggle {
+  background: none;
+  border: none;
+  padding: 2px;
+  cursor: pointer;
+  color: $grey-color;
+  vertical-align: middle;
+  line-height: 1;
+  transition: color 0.15s ease;
+
+  &:hover {
+    color: $brand-color;
+  }
+}
+
+.nav-search--open .nav-search__toggle {
+  color: $brand-color;
+}
+
+.nav-search__input {
+  position: absolute;
+  left: 100%;
+  top: 50%;
+  transform: translateY(-50%);
+  margin-left: 6px;
+  font-family: $base-font-family;
+  font-size: 14px;
+  padding: 5px 10px;
+  width: 200px;
+  border: 1px solid $grey-color-light;
+  border-radius: 5px;
+  background: #fff;
+  color: $text-color;
+  outline: none;
+  opacity: 0;
+  pointer-events: none;
+  transition: opacity 0.15s ease;
+
+  &:focus {
+    border-color: $brand-color;
+    box-shadow: 0 0 0 2px rgba($brand-color, 0.1);
+  }
+
+  &::placeholder {
+    color: $grey-color;
+  }
+}
+
+.nav-search--open .nav-search__input {
+  opacity: 1;
+  pointer-events: auto;
+}
+
+.nav-search__results {
+  display: none;
+  position: absolute;
+  top: calc(100% + 8px);
+  right: 0;
+  width: 360px;
+  max-height: 380px;
+  overflow-y: auto;
+  background: #fff;
+  border: 1px solid $grey-color-light;
+  border-radius: 8px;
+  box-shadow: 0 4px 16px rgba(0, 0, 0, 0.1);
+  z-index: 1000;
+}
+
+.nav-search__item {
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+  gap: 12px;
+  padding: 8px 12px;
+  text-decoration: none;
+  border-bottom: 1px solid rgba($grey-color-light, 0.5);
+  transition: background 0.1s ease;
+
+  &:last-child {
+    border-bottom: none;
+  }
+
+  &:hover {
+    background: rgba($brand-color, 0.04);
+    text-decoration: none;
+  }
+
+  &:visited {
+    .nav-search__item-title {
+      color: $text-color;
+    }
+  }
+}
+
+.nav-search__item-title {
+  font-size: 14px;
+  font-weight: 500;
+  color: $text-color;
+  line-height: 1.3;
+}
+
+.nav-search__item-date {
+  font-size: 12px;
+  color: $grey-color;
+  white-space: nowrap;
+  flex-shrink: 0;
+}
+
+.nav-search__empty {
+  padding: 12px;
+  font-size: 14px;
+  color: $grey-color;
+  text-align: center;
+}
+
+.nav-search__more {
+  display: block;
+  padding: 8px 12px;
+  font-size: 13px;
+  font-weight: 500;
+  color: $brand-color;
+  text-align: center;
+  text-decoration: none;
+  border-top: 1px solid $grey-color-light;
+
+  &:hover {
+    background: rgba($brand-color, 0.04);
+    text-decoration: none;
+  }
+
+  &:visited {
+    color: $brand-color;
+  }
+}
+
+// ————————————————————————————————————
 // Mobile
 // ————————————————————————————————————
 
@@ -702,4 +887,43 @@ hr {
     font-size: 10px;
     padding: 1px 6px;
   }
+
+  .nav-search__input {
+    position: static;
+    transform: none;
+    display: block;
+    width: 100%;
+    opacity: 0;
+    pointer-events: none;
+    max-height: 0;
+    padding: 0;
+    border: none;
+    margin: 0;
+    transition: opacity 0.15s ease, max-height 0.15s ease, padding 0.15s ease, margin 0.15s ease;
+  }
+
+  .nav-search--open .nav-search__input {
+    opacity: 1;
+    pointer-events: auto;
+    max-height: 40px;
+    padding: 5px 10px;
+    margin: 8px 0 0 0;
+    border: 1px solid $grey-color-light;
+  }
+
+  .nav-search__results {
+    position: static;
+    width: 100%;
+    max-height: 300px;
+    border-radius: 0 0 5px 5px;
+    box-shadow: none;
+    border: 1px solid $grey-color-light;
+    border-top: none;
+    margin-top: 0;
+  }
+
+  .nav-search {
+    display: block;
+  }
+
 }

--- a/search.html
+++ b/search.html
@@ -1,0 +1,130 @@
+---
+layout: page
+title: Search
+permalink: /search/
+---
+
+<div class="search-page">
+  <div class="search-input-wrap">
+    <input type="text" id="search-input" class="search-input" placeholder="Search posts..." autocomplete="off" autofocus>
+  </div>
+  <div id="search-results" class="search-results"></div>
+  <div id="search-status" class="search-status"></div>
+</div>
+
+<script>
+(function() {
+  var input = document.getElementById('search-input');
+  var resultsEl = document.getElementById('search-results');
+  var statusEl = document.getElementById('search-status');
+  var posts = null;
+  var debounceTimer = null;
+
+  // Load the search index
+  var xhr = new XMLHttpRequest();
+  xhr.open('GET', '{{ "/search.json" | relative_url }}');
+  xhr.onload = function() {
+    if (xhr.status === 200) {
+      posts = JSON.parse(xhr.responseText);
+    }
+  };
+  xhr.send();
+
+  // Pre-populate from query string (e.g., /search/?q=kubernetes)
+  var params = new URLSearchParams(window.location.search);
+  var initialQuery = params.get('q');
+  if (initialQuery) {
+    input.value = initialQuery;
+  }
+
+  input.addEventListener('input', function() {
+    clearTimeout(debounceTimer);
+    debounceTimer = setTimeout(doSearch, 200);
+  });
+
+  // Run initial search if query param was present
+  if (initialQuery) {
+    var waitForPosts = setInterval(function() {
+      if (posts) {
+        clearInterval(waitForPosts);
+        doSearch();
+      }
+    }, 50);
+  }
+
+  function doSearch() {
+    var query = input.value.trim().toLowerCase();
+
+    if (!query) {
+      resultsEl.innerHTML = '';
+      statusEl.innerHTML = '';
+      return;
+    }
+
+    if (!posts) {
+      statusEl.innerHTML = '<p class="search-message">Loading search index...</p>';
+      return;
+    }
+
+    var words = query.split(/\s+/).filter(function(w) { return w.length > 0; });
+    var scored = [];
+
+    for (var i = 0; i < posts.length; i++) {
+      var post = posts[i];
+      var score = 0;
+      var titleLower = post.title.toLowerCase();
+      var tagsLower = post.tags.map(function(t) { return t.toLowerCase(); });
+      var contentLower = post.content.toLowerCase();
+
+      for (var j = 0; j < words.length; j++) {
+        var w = words[j];
+        // Title matches worth the most
+        if (titleLower.indexOf(w) !== -1) score += 10;
+        // Tag matches
+        for (var k = 0; k < tagsLower.length; k++) {
+          if (tagsLower[k].indexOf(w) !== -1) score += 5;
+        }
+        // Content matches
+        if (contentLower.indexOf(w) !== -1) score += 1;
+      }
+
+      if (score > 0) {
+        scored.push({ post: post, score: score });
+      }
+    }
+
+    // Sort by score descending
+    scored.sort(function(a, b) { return b.score - a.score; });
+
+    if (scored.length === 0) {
+      resultsEl.innerHTML = '';
+      statusEl.innerHTML = '<p class="search-message">No posts found for "' + escapeHtml(input.value.trim()) + '"</p>';
+      return;
+    }
+
+    statusEl.innerHTML = '<p class="search-message">' + scored.length + ' result' + (scored.length === 1 ? '' : 's') + ' found</p>';
+
+    var html = '<ul class="post-list">';
+    for (var i = 0; i < scored.length; i++) {
+      var post = scored[i].post;
+      var excerpt = post.excerpt;
+      if (excerpt.length > 200) {
+        excerpt = excerpt.substring(0, 200) + '...';
+      }
+      html += '<li>';
+      html += '<span class="post-meta">' + escapeHtml(post.date) + '</span>';
+      html += '<h3><a class="post-link" href="' + escapeHtml(post.url) + '">' + escapeHtml(post.title) + '</a></h3>';
+      html += '<p>' + escapeHtml(excerpt) + '</p>';
+      html += '</li>';
+    }
+    html += '</ul>';
+    resultsEl.innerHTML = html;
+  }
+
+  function escapeHtml(text) {
+    var el = document.createElement('div');
+    el.appendChild(document.createTextNode(text));
+    return el.innerHTML;
+  }
+})();
+</script>

--- a/search.json
+++ b/search.json
@@ -1,0 +1,16 @@
+---
+layout: null
+---
+[
+  {%- assign date_format = site.minima.date_format | default: "%b %-d, %Y" -%}
+  {%- for post in site.posts -%}
+  {
+    "title": {{ post.title | jsonify }},
+    "url": {{ post.url | relative_url | jsonify }},
+    "date": {{ post.date | date: date_format | jsonify }},
+    "tags": {{ post.tags | jsonify }},
+    "excerpt": {{ post.excerpt | strip_html | strip_newlines | jsonify }},
+    "content": {{ post.content | strip_html | strip_newlines | jsonify }}
+  }{%- unless forloop.last -%},{%- endunless -%}
+  {%- endfor -%}
+]


### PR DESCRIPTION
## Summary
- Adds a search icon to the nav bar that expands an input field to the right on click
- Results appear in a dropdown with title + date, scored by keyword matches across title (10pts), tags (5pts), and content (1pt)
- Full-page search fallback at /search/ accessible via "view all" link
- Mobile-responsive: input and results flow inside the hamburger menu on small screens
- XSS-safe rendering via DOM text node creation

## Test plan
- [ ] Click search icon - input expands to the right
- [ ] Type a query - results appear in dropdown with post title and date
- [ ] Click a result - navigates to the post
- [ ] Click outside or press Escape - search closes
- [ ] Test on mobile viewport - search input appears inside hamburger menu
- [ ] "View all" link works when more than 6 results