### PR TITLE
Update homepage intro text

### DIFF
--- a/index.md
+++ b/index.md
@@ -7,7 +7,7 @@ description: "Nir Yechiel's personal website — writing about product engineeri
 
 <div class="home-intro" markdown="1">
 
-I am a product manager at Red Hat, building agentic AI systems that reimagine how enterprise teams work. Previously led engineering teams on OpenShift Networking (Submariner, Service Mesh, Gateway API, Service Interconnect) and held engineering and product roles at Red Hat, Facebook (Meta), and Cisco.
+I'm currently a product manager at Red Hat, working on agentic AI for enterprise teams. I've been on both sides of the build - engineering leadership and product - and I write about AI, product craft, and the human side of shipping software.
 
 </div>
 


### PR DESCRIPTION
## Summary
- Replaces the career-summary intro with a more distinctive, concise description
- Focuses on current role (agentic AI at Red Hat), cross-functional experience, and writing topics

## Test plan
- [x] Verify homepage intro reads well and renders correctly
- [x] Check mobile rendering