### PR TITLE
Remove divider line between homepage intro and featured post

### DIFF
--- a/assets/main.scss
+++ b/assets/main.scss
@@ -310,9 +310,7 @@ table {
 .home-intro {
   font-size: 19px;
   line-height: 1.6;
-  padding-bottom: $spacing-unit * 1.2;
-  margin-bottom: $spacing-unit * 1.2;
-  border-bottom: 1px solid $grey-color-light;
+  margin-bottom: $spacing-unit;
   color: $grey-color-dark;
 }
 


### PR DESCRIPTION
## Summary
- Removes the horizontal line (border-bottom) between the intro text and the featured post card
- Reduces spacing for a cleaner visual flow

## Test plan
- [x] Verify homepage has no divider line between intro and featured card
- [x] Check spacing looks balanced on desktop and mobile