### PR TITLE
Fix llms.txt Liquid syntax for GitHub Pages

### DIFF
--- a/llms.txt
+++ b/llms.txt
@@ -18,7 +18,7 @@ The blog reflects this journey: early posts are deep technical content on networ
 {%- endfor %}
 
 ## Career and Leadership
-{% assign career_posts = site.posts | where_exp: "post", "post.tags contains 'Career' or post.tags contains 'Management' or post.tags contains 'People'" %}{% assign career_no_ai = "" | split: "" %}{% for post in career_posts %}{% unless post.tags contains 'AI' %}{% assign career_no_ai = career_no_ai | push: post %}{% endunless %}{% endfor %}
+{% assign career_no_ai = "" | split: "" %}{% for post in site.posts %}{% if post.tags contains 'Career' or post.tags contains 'Management' or post.tags contains 'People' %}{% unless post.tags contains 'AI' %}{% assign career_no_ai = career_no_ai | push: post %}{% endunless %}{% endif %}{% endfor %}
 {%- for post in career_no_ai %}
 - [{{ post.title }}]({{ site.url }}{{ post.url }}): {{ post.excerpt | strip_html | strip_newlines | truncatewords: 30 }}
 {%- endfor %}


### PR DESCRIPTION
## Summary
- Fixes the deployment failure caused by `or` inside `where_exp`, which Liquid 4.0 (GitHub Pages) doesn't support
- Moves multi-tag filtering into an `{% if %}` block where `or` is supported

Fixes the build error: `Liquid syntax error (line 16): Expected end_of_string but found id`

## Test plan
- [x] Verify GitHub Pages build passes
- [x] Verify llms.txt renders correctly with all three sections populated