### PR TITLE
Improve mobile search appearance in hamburger menu

### DIFF
--- a/assets/main.scss
+++ b/assets/main.scss
@@ -886,27 +886,26 @@ hr {
     padding: 1px 6px;
   }
 
+  .nav-search {
+    display: block;
+    padding: 5px 0;
+  }
+
+  .nav-search__toggle {
+    display: none;
+  }
+
   .nav-search__input {
     position: static;
     transform: none;
     display: block;
     width: 100%;
-    opacity: 0;
-    pointer-events: none;
-    max-height: 0;
-    padding: 0;
-    border: none;
-    margin: 0;
-    transition: opacity 0.15s ease, max-height 0.15s ease, padding 0.15s ease, margin 0.15s ease;
-  }
-
-  .nav-search--open .nav-search__input {
     opacity: 1;
     pointer-events: auto;
-    max-height: 40px;
-    padding: 5px 10px;
-    margin: 8px 0 0 0;
+    padding: 8px 10px;
     border: 1px solid $grey-color-light;
+    border-radius: 5px;
+    font-size: 15px;
   }
 
   .nav-search__results {
@@ -918,10 +917,6 @@ hr {
     border: 1px solid $grey-color-light;
     border-top: none;
     margin-top: 0;
-  }
-
-  .nav-search {
-    display: block;
   }
 
 }


### PR DESCRIPTION
## Summary
- Hides the search toggle icon on mobile - it looked awkward floating alone on a line
- Shows the search input directly as a full-width text box inside the hamburger menu
- No toggle needed on mobile since the menu itself is already toggled

## Test plan
- [ ] Open site on mobile - search input appears as a clean text field inside the nav menu
- [ ] Type a query - results appear below the input
- [ ] Desktop behavior unchanged - icon + expand-right still works