### PR TITLE
Improve SEO, structured data, and LLM discoverability

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -14,7 +14,10 @@
 # You can create any custom variable you would like, and they will be accessible
 # in the templates via {{ site.myvariable }}.
 title: Nir Yechiel's Blog
-author: Nir Yechiel
+author:
+  name: Nir Yechiel
+  url: https://nyechiel.com/about/
+  twitter: nyechiel
 # email: n.yechiel@gmail.com # Removed to prevent spam - contact via social links
 description: >- # this means to ignore newlines until "baseurl:"
   Random thoughts on product engineering, technology, people, and where they intersect.
@@ -38,6 +41,12 @@ social:
     - https://twitter.com/nyechiel
     - https://www.linkedin.com/in/nyechiel
     - https://github.com/nyechiel
+
+# Twitter/X card metadata (also used by Slack, LinkedIn, Discord for link previews)
+twitter:
+  username: nyechiel
+  card: summary_large_image
+
 # Build settings
 markdown: kramdown
 theme: minima
@@ -50,10 +59,6 @@ plugins:
 feed:
   posts_limit: 50
   excerpt_only: false
-
-# Twitter/X card type
-twitter:
-  card: summary_large_image
 
 exclude:
   - CLAUDE.md

--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -1,0 +1,35 @@
+<footer class="site-footer h-card">
+  <data class="u-url" href="{{ "/" | relative_url }}"></data>
+
+  <div class="wrapper">
+
+    <h2 class="footer-heading">{{ site.title | escape }}</h2>
+
+    <div class="footer-col-wrapper">
+      <div class="footer-col footer-col-1">
+        <ul class="contact-list">
+          <li class="p-name">
+            {%- if site.author -%}
+              {{ site.author.name | default: site.author | escape }}
+            {%- else -%}
+              {{ site.title | escape }}
+            {%- endif -%}
+            </li>
+            {%- if site.email -%}
+            <li><a class="u-email" href="mailto:{{ site.email }}">{{ site.email }}</a></li>
+            {%- endif -%}
+        </ul>
+      </div>
+
+      <div class="footer-col footer-col-2">
+        {%- include social.html -%}
+      </div>
+
+      <div class="footer-col footer-col-3">
+        <p>{{- site.description | escape -}}</p>
+      </div>
+    </div>
+
+  </div>
+
+</footer>

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -12,5 +12,6 @@
     {%- include google-analytics.html -%}
   {%- endif -%}
   {% seo %}
+  {% include structured-data.html %}
   <meta name="follow.it-verification-code" content="hP40yF01ZckKrsGaykxn"/>
 </head>

--- a/_includes/structured-data.html
+++ b/_includes/structured-data.html
@@ -1,0 +1,28 @@
+{% if page.layout == "post" %}
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "BlogPosting",
+  "mainEntityOfPage": {
+    "@type": "WebPage",
+    "@id": "{{ page.url | absolute_url }}"
+  },
+  "headline": {{ page.title | jsonify }},
+  "description": {{ page.description | default: page.excerpt | strip_html | strip_newlines | truncatewords: 50 | jsonify }},
+  "datePublished": "{{ page.date | date_to_xmlschema }}",
+  "dateModified": "{{ page.modified_date | default: page.date | date_to_xmlschema }}",
+  {% if page.image %}"image": "{{ page.image.path | default: page.image | absolute_url }}",{% endif %}
+  "author": {
+    "@type": "Person",
+    "name": "{{ site.author.name }}",
+    "url": "{{ site.author.url }}",
+    "sameAs": [{% for link in site.social.links %}"{{ link }}"{% unless forloop.last %}, {% endunless %}{% endfor %}]
+  },
+  "publisher": {
+    "@type": "Person",
+    "name": "{{ site.author.name }}",
+    "url": "{{ site.url }}"
+  }
+}
+</script>
+{% endif %}

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -1,0 +1,21 @@
+---
+layout: null
+sitemap:
+  exclude: 'yes'
+---
+# {{ site.title }}
+
+> Personal blog of Nir Yechiel, a Senior Principal Product Manager at Red Hat focused on AI and enterprise software. Covers AI-augmented workflows, product management, networking, OpenStack, Kubernetes, and career reflections. Active since {{ site.posts.last.date | date: "%Y" }}, with {{ site.posts.size }} posts. Last published: {{ site.posts.first.date | date: "%B %Y" }}.
+
+{% for post in site.posts %}
+---
+
+## {{ post.title }}
+
+- URL: {{ site.url }}{{ post.url }}
+- Date: {{ post.date | date: "%Y-%m-%d" }}
+- Tags: {{ post.tags | join: ", " }}
+
+{{ post.content | strip_html | strip_newlines | replace: "  ", " " }}
+
+{% endfor %}

--- a/robots.txt
+++ b/robots.txt
@@ -6,3 +6,4 @@ Disallow: /redirects.json
 
 Sitemap: https://nyechiel.com/sitemap.xml
 Llms-txt: https://nyechiel.com/llms.txt
+Llms-full-txt: https://nyechiel.com/llms-full.txt


### PR DESCRIPTION
## Summary

- Add `llms-full.txt` with complete post content (145 KB) so LLMs can ingest the entire blog in one fetch - this is the biggest lever for fixing the "ChatGPT thinks the blog stopped in 2022" problem
- Fix Twitter/X card metadata: `twitter:site` was rendering as `@` (empty) and `twitter:creator` as `@Nir Yechiel` (space in handle) - both now correctly show `@nyechiel`
- Add supplementary JSON-LD on blog posts with `publisher` and `author.sameAs` social links (Twitter, LinkedIn, GitHub) - neither of which `jekyll-seo-tag` generates on its own
- Override minima's `footer.html` to handle `author` as an object (needed after changing author from a string to an object with name/url/twitter in `_config.yml`)
- Reference `llms-full.txt` in `robots.txt`

## Test plan

- [x] Verify footer displays "Nir Yechiel" (not a raw hash)
- [x] Verify Twitter/X icon still appears in footer social links
- [x] Verify link previews show correct metadata when sharing a post URL (Slack, LinkedIn, etc.)
- [x] Visit `/llms-full.txt` and confirm all 31 posts appear with full content
- [x] Check a blog post page source for two valid JSON-LD blocks (one from jekyll-seo-tag, one supplementary with publisher/sameAs)
- [x] Check a non-post page (e.g., /about/) has only one JSON-LD block (no supplementary)