### PR TITLE
Fix custom 404 page and subscribe form

### DIFF
--- a/.github/workflows/pr-tests.yml
+++ b/.github/workflows/pr-tests.yml
@@ -184,8 +184,8 @@ jobs:
 
     - name: Check 404 page has navigation links
       run: |
-        grep -q 'href="/blog/"' _site/404/index.html
-        grep -q 'href="/search/"' _site/404/index.html
+        grep -q 'href="/blog/"' _site/404.html
+        grep -q 'href="/search/"' _site/404.html
         echo "404 page has navigation links"
 
     - name: Check URL validator rejects path traversal

--- a/404.html
+++ b/404.html
@@ -1,4 +1,5 @@
 ---
+permalink: /404.html
 layout: default
 sitemap:
   exclude: 'yes'

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -16,7 +16,7 @@
   {% seo %}
   {% include structured-data.html %}
   <meta name="follow.it-verification-code" content="hP40yF01ZckKrsGaykxn"/>
-  <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' https://unpkg.com; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src https://fonts.gstatic.com; img-src 'self' https://avatars.githubusercontent.com data:; connect-src 'self' https://api.github.com https://api.follow.it; form-action 'self' https://api.follow.it; frame-ancestors 'none'; base-uri 'self'; object-src 'none';">
+  <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' https://unpkg.com; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src https://fonts.gstatic.com; img-src 'self' https://avatars.githubusercontent.com data:; connect-src 'self' https://api.github.com https://api.follow.it; form-action 'self' https://api.follow.it https://follow.it; frame-ancestors 'none'; base-uri 'self'; object-src 'none';">
   <meta http-equiv="X-Content-Type-Options" content="nosniff">
   <meta http-equiv="Referrer-Policy" content="strict-origin-when-cross-origin">
 </head>


### PR DESCRIPTION
## Summary

- **404 page not showing:** Jekyll was outputting `404/index.html` instead of `404.html`. GitHub Pages requires the custom 404 at the site root as `404.html`. Added `permalink: /404.html` to the front matter.
- **Subscribe form broken:** The form POSTs to `api.follow.it`, which redirects to `follow.it` for confirmation. The CSP `form-action` only allowed `api.follow.it`, so the browser blocked the redirect. Added `https://follow.it` to the directive.
- Updated CI test path for 404 page accordingly.

## Test plan

- [x] Visit a non-existent URL (e.g., `/asdfasdf`) and verify the custom 404 page appears with Home/Blog/Search links
- [x] Submit the subscribe form with an email and verify it redirects to the follow.it confirmation page
- [x] CI passes (site-checks job verifies 404 nav links and CSP meta tag)