### PR TITLE
Add deploy, CodeQL, and license badges to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,9 @@
 # nyechiel.github.io
 
 [![PR Tests](https://github.com/nyechiel/nyechiel.github.io/actions/workflows/pr-tests.yml/badge.svg)](https://github.com/nyechiel/nyechiel.github.io/actions/workflows/pr-tests.yml)
+[![Deploy](https://github.com/nyechiel/nyechiel.github.io/actions/workflows/pages/pages-build-deployment/badge.svg)](https://github.com/nyechiel/nyechiel.github.io/actions/workflows/pages/pages-build-deployment)
+[![CodeQL](https://github.com/nyechiel/nyechiel.github.io/actions/workflows/codeql-analysis.yml/badge.svg)](https://github.com/nyechiel/nyechiel.github.io/actions/workflows/codeql-analysis.yml)
+[![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
 
 Source code for [nyechiel.com](https://nyechiel.com) - a personal blog about AI, product craft, and the human side of shipping software.
 


### PR DESCRIPTION
## Summary
- Added GitHub Pages deploy status badge
- Added CodeQL security analysis badge
- Added MIT license badge

## Test plan
- [x] All four badges render on the README
- [x] Each badge links to the correct workflow/file