### PR TITLE
Add Notes section as a Jekyll collection

### DIFF
--- a/.github/workflows/pr-tests.yml
+++ b/.github/workflows/pr-tests.yml
@@ -72,7 +72,7 @@ jobs:
 
     - name: Check aria-label on nav search input
       run: |
-        grep -q 'aria-label="Search posts"' _site/index.html
+        grep -q 'aria-label="Search posts and notes"' _site/index.html
         echo "search input aria-label found"
 
     - name: Check aria-live on search results
@@ -85,6 +85,37 @@ jobs:
       run: |
         grep -q 'loading="lazy"' _site/index.html
         echo "lazy loading found on homepage"
+
+    - name: Check notes index page exists
+      run: |
+        test -f _site/notes/index.html
+        grep -q 'note-disclaimer' _site/notes/index.html
+        echo "notes index page found with disclaimer"
+
+    - name: Check notes excluded from RSS feed
+      run: |
+        if grep -q '/notes/' _site/feed.xml; then
+          echo "FAIL: notes URLs found in RSS feed"
+          exit 1
+        fi
+        echo "notes correctly excluded from feed"
+
+    - name: Check note layout exists
+      run: |
+        test -f _layouts/note.html
+        grep -q 'note-context' _layouts/note.html
+        echo "note layout found"
+
+    - name: Check search.json includes type field
+      run: |
+        python3 -c "
+        import json
+        with open('_site/search.json') as f:
+            data = json.load(f)
+        for item in data:
+            assert 'type' in item, f'Missing type field in: {item.get(\"title\", \"unknown\")}'
+        print(f'All {len(data)} search entries have type field')
+        "
 
     - name: Check external JS files exist
       run: |

--- a/_config.yml
+++ b/_config.yml
@@ -28,9 +28,22 @@ show_excerpts: true
 header_pages:
   - index.md
   - blog/index.md
+  - notes/index.html
   - tags.html
   - podcasts.md
   - about.md
+
+collections:
+  notes:
+    output: true
+    permalink: /notes/:title/
+
+defaults:
+  - scope:
+      path: ""
+      type: "notes"
+    values:
+      layout: "note"
 twitter_username: nyechiel
 github_username: nyechiel
 linkedin_username: nyechiel

--- a/_includes/header.html
+++ b/_includes/header.html
@@ -23,6 +23,7 @@
             {%- assign is_active = false -%}
             {%- if page.url == my_page.url -%}{%- assign is_active = true -%}{%- endif -%}
             {%- if my_page.url == "/blog/" and page.layout == "post" -%}{%- assign is_active = true -%}{%- endif -%}
+            {%- if my_page.url == "/notes/" and page.layout == "note" -%}{%- assign is_active = true -%}{%- endif -%}
             <a class="page-link{% if is_active %} page-link--active{% endif %}" href="{{ my_page.url | relative_url }}">{{ my_page.title | escape }}</a>
             {%- endif -%}
           {%- endfor -%}
@@ -30,7 +31,7 @@
             <button type="button" class="nav-search__toggle" id="nav-search-toggle" aria-label="Search">
               <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="11" cy="11" r="8"/><line x1="21" y1="21" x2="16.65" y2="16.65"/></svg>
             </button>
-            <input type="text" id="nav-search-input" class="nav-search__input" placeholder="Search posts..." autocomplete="off" aria-label="Search posts">
+            <input type="text" id="nav-search-input" class="nav-search__input" placeholder="Search..." autocomplete="off" aria-label="Search posts and notes">
             <div id="nav-search-results" class="nav-search__results" aria-live="polite"></div>
           </span>
         </div>

--- a/_layouts/note.html
+++ b/_layouts/note.html
@@ -1,0 +1,39 @@
+---
+layout: default
+---
+<article class="post">
+
+  <header class="post-header">
+    <h1 class="post-title">{{ page.title | escape }}</h1>
+    <p class="post-meta">
+      {%- assign date_format = site.minima.date_format | default: "%b %-d, %Y" -%}
+      <time datetime="{{ page.date | date_to_xmlschema }}">
+        {{ page.date | date: date_format }}
+      </time>
+      {%- if page.last_updated -%}
+        &nbsp;&middot;&nbsp; Updated
+        <time datetime="{{ page.last_updated | date_to_xmlschema }}">
+          {{ page.last_updated | date: date_format }}
+        </time>
+      {%- endif -%}
+    </p>
+    {%- if page.tags.size > 0 -%}
+      <ul class="post-tags">
+        {%- for tag in page.tags -%}
+          <li><a class="post-tag post-tag--link" href="{{ "/tags/" | relative_url }}#{{ tag | slugify }}">{{ tag | escape }}</a></li>
+        {%- endfor -%}
+      </ul>
+    {%- endif -%}
+  </header>
+
+  <div class="note-context">
+    This is a <a href="{{ "/notes/" | relative_url }}">working note</a> - shorter and less polished than a blog post, and may evolve over time.
+  </div>
+
+  <div class="post-content">
+    {{ content }}
+  </div>
+
+  <p class="note-back"><a href="{{ "/notes/" | relative_url }}">&larr; All Notes</a></p>
+
+</article>

--- a/_notes/jobs-to-be-done.md
+++ b/_notes/jobs-to-be-done.md
@@ -1,0 +1,27 @@
+---
+title: "Moving to Jobs to Be Done"
+date: 2026-07-04
+published: false
+tags:
+  - Product Management
+  - Frameworks
+description: "Why I'm shifting my product thinking toward JTBD, and what that looks like in practice."
+---
+
+I've been moving my product thinking toward a Jobs to Be Done (JTBD) framework. This note captures the shift as it happens.
+
+## Why the shift
+
+*TODO: What prompted the move - what wasn't working with the previous mental model?*
+
+## What JTBD means to me
+
+*TODO: Your working definition and how you're applying it day-to-day.*
+
+## Resources that shaped my thinking
+
+*TODO: Podcasts, books, articles that influenced this direction.*
+
+## Open questions
+
+*TODO: Things you're still figuring out as you apply JTBD in practice.*

--- a/assets/js/nav-search.js
+++ b/assets/js/nav-search.js
@@ -91,9 +91,14 @@
     var html = '';
     for (var i = 0; i < max; i++) {
       var p = scored[i].post;
+      var typeLabel = p.type === 'note' ? 'Note' : 'Blog';
+      var typeClass = p.type === 'note' ? 'nav-search__item-type--note' : 'nav-search__item-type--post';
       html += '<a class="nav-search__item" href="' + esc(p.url) + '">';
       html += '<span class="nav-search__item-title">' + esc(p.title) + '</span>';
+      html += '<span class="nav-search__item-meta">';
+      html += '<span class="nav-search__item-type ' + typeClass + '">' + typeLabel + '</span>';
       html += '<span class="nav-search__item-date">' + esc(p.date) + '</span>';
+      html += '</span>';
       html += '</a>';
     }
     if (scored.length > max) {

--- a/assets/js/search.js
+++ b/assets/js/search.js
@@ -80,7 +80,7 @@
 
     if (scored.length === 0) {
       resultsEl.innerHTML = '';
-      statusEl.innerHTML = '<p class="search-message">No posts found for "' + escapeHtml(input.value.trim()) + '"</p>';
+      statusEl.innerHTML = '<p class="search-message">No results found for "' + escapeHtml(input.value.trim()) + '"</p>';
       return;
     }
 
@@ -93,9 +93,11 @@
       if (excerpt.length > 200) {
         excerpt = excerpt.substring(0, 200) + '...';
       }
+      var typeLabel = post.type === 'note' ? 'Note' : 'Blog';
+      var badgeClass = post.type === 'note' ? 'note-badge' : 'post-type-badge';
       html += '<li>';
       html += '<span class="post-meta">' + escapeHtml(post.date) + '</span>';
-      html += '<h3><a class="post-link" href="' + escapeHtml(post.url) + '">' + escapeHtml(post.title) + '</a></h3>';
+      html += '<h3><a class="post-link" href="' + escapeHtml(post.url) + '">' + escapeHtml(post.title) + '</a> <span class="' + badgeClass + '">' + typeLabel + '</span></h3>';
       html += '<p>' + escapeHtml(excerpt) + '</p>';
       html += '</li>';
     }

--- a/assets/main.scss
+++ b/assets/main.scss
@@ -200,7 +200,9 @@ a {
 // Post content
 // ————————————————————————————————————
 
-.post-title {
+.post-title,
+.page-heading {
+  font-size: 42px;
   font-weight: 700;
   color: #1a1a2e;
   line-height: 1.15;
@@ -330,9 +332,6 @@ table {
 
 .home {
   .page-heading {
-    font-weight: 700;
-    font-size: 28px;
-    color: #1a1a2e;
     margin-bottom: $spacing-unit;
   }
 }
@@ -606,6 +605,64 @@ hr {
 }
 
 // ————————————————————————————————————
+// Notes
+// ————————————————————————————————————
+
+.note-disclaimer {
+  line-height: 1.6;
+  margin-bottom: $spacing-unit * 1.5;
+  padding-bottom: $spacing-unit;
+  border-bottom: 1px solid $grey-color-light;
+}
+
+.note-context {
+  font-size: 14px;
+  color: $grey-color;
+  margin-bottom: $spacing-unit;
+  padding: 8px 14px;
+  background: rgba($brand-color, 0.04);
+  border-radius: 6px;
+
+  a {
+    color: $grey-color;
+    text-decoration: underline;
+    text-decoration-color: rgba($grey-color, 0.3);
+
+    &:hover {
+      color: $brand-color;
+    }
+  }
+}
+
+.note-back {
+  margin-top: $spacing-unit * 1.5;
+  font-size: 15px;
+
+  a {
+    color: $grey-color;
+    text-decoration: none;
+
+    &:hover {
+      color: $brand-color;
+    }
+  }
+}
+
+.note-badge {
+  display: inline-block;
+  font-size: 11px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  color: $grey-color;
+  background: rgba($grey-color, 0.1);
+  padding: 2px 8px;
+  border-radius: 4px;
+  vertical-align: middle;
+  margin-left: 6px;
+}
+
+// ————————————————————————————————————
 // Tags page
 // ————————————————————————————————————
 
@@ -776,7 +833,7 @@ hr {
 .nav-search__item {
   display: flex;
   justify-content: space-between;
-  align-items: baseline;
+  align-items: center;
   gap: 12px;
   padding: 8px 12px;
   text-decoration: none;
@@ -806,11 +863,52 @@ hr {
   line-height: 1.3;
 }
 
+.nav-search__item-meta {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  flex-shrink: 0;
+  white-space: nowrap;
+  line-height: 1;
+}
+
+.nav-search__item-type {
+  font-size: 10px;
+  font-weight: 500;
+  letter-spacing: 0.01em;
+  padding: 1px 7px;
+  border-radius: 10px;
+}
+
+.nav-search__item-type--post {
+  color: $brand-color;
+  background: rgba($brand-color, 0.08);
+}
+
+.nav-search__item-type--note {
+  color: #6c5ce7;
+  background: rgba(#6c5ce7, 0.08);
+}
+
 .nav-search__item-date {
   font-size: 12px;
   color: $grey-color;
   white-space: nowrap;
   flex-shrink: 0;
+}
+
+.post-type-badge {
+  display: inline-block;
+  font-size: 11px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  color: $brand-color;
+  background: rgba($brand-color, 0.08);
+  padding: 2px 8px;
+  border-radius: 4px;
+  vertical-align: middle;
+  margin-left: 6px;
 }
 
 .nav-search__empty {
@@ -849,7 +947,8 @@ hr {
     font-size: 16px;
   }
 
-  .post-title {
+  .post-title,
+  .page-heading {
     font-size: 26px;
     line-height: 1.2;
   }
@@ -962,6 +1061,16 @@ hr {
     border-top: none;
     margin-top: 0;
     text-align: left;
+  }
+
+  .nav-search__item-type {
+    font-size: 11px;
+    padding: 2px 8px;
+  }
+
+  .note-badge {
+    font-size: 10px;
+    padding: 1px 6px;
   }
 
 }

--- a/index.md
+++ b/index.md
@@ -50,6 +50,22 @@ Outside of work, you'll find me running, on a yoga mat, or lost in music.
 
 [View All Posts →](/blog/)
 
+{% assign recent_notes = site.notes | sort: "date" | reverse %}
+{% if recent_notes.size > 0 %}
+## Latest Notes
+
+{% for note in recent_notes limit:3 %}
+<small>{{ note.date | date: "%B %-d, %Y" }}</small>
+
+**[{{ note.title }}]({{ note.url }})**
+
+{% if note.description %}{{ note.description }}{% endif %}
+
+{% endfor %}
+
+[View All Notes →](/notes/)
+{% endif %}
+
 <div class="subscribe-card">
   <p class="subscribe-card__text">Like what you're reading? Get new posts straight to your inbox.</p>
   <form class="subscribe-card__form" action="https://api.follow.it/subscription-form/clBXWVBSbWJyanNERlN2VVRGTUNNdU1uSTF3b1hLRTBGcStIa282RFpaWEVpOVNuOXhieituSC9mVENiTUYzYmRXK25PVVRJM2ZGd3Z0NGVuc0N2R1gxa1lOK1A2S1FrRTEzVXhkZjBvb0xhN2d4L2QxOHpiZ0l1N3V3NmZyRmV8RDY2VzhJN1NzSTJsUyt4L0xTYlJiSkgvUnV6QVdjWjBTem9PQXRFNjBlYz0=/8" method="post">

--- a/llms.txt
+++ b/llms.txt
@@ -9,7 +9,7 @@ sitemap:
 
 Nir started in computer networking (Cisco, Red Hat), moved to product management for OpenStack and OpenShift, spent time at Facebook/Meta on connectivity infrastructure, then returned to Red Hat in engineering management leading OpenShift networking teams (Submariner, Service Mesh, Gateway API, Service Interconnect). In 2026 he transitioned back to product management, focused on AI.
 
-The blog reflects this journey: early posts are deep technical content on networking and OpenStack, middle posts cover career transitions and leadership, and recent posts focus on AI-augmented product management workflows.
+The blog reflects this journey: early posts are deep technical content on networking and OpenStack, middle posts cover career transitions and leadership, and recent posts focus on AI-augmented product management workflows. The site also includes a Notes section with shorter, less polished working notes on product thinking, frameworks, and ideas.
 
 ## AI and Product Management
 {% assign ai_posts = site.posts | where_exp: "post", "post.tags contains 'AI'" %}
@@ -29,9 +29,18 @@ The blog reflects this journey: early posts are deep technical content on networ
 - [{{ post.title }}]({{ site.url }}{{ post.url }}): {{ post.excerpt | strip_html | strip_newlines | truncatewords: 30 }}
 {%- endfor %}
 
+{%- if site.notes.size > 0 %}
+
+## Notes
+{% for note in site.notes %}
+- [{{ note.title }}]({{ site.url }}{{ note.url }}): {{ note.description | default: note.content | strip_html | strip_newlines | truncatewords: 30 }}
+{%- endfor %}
+{%- endif %}
+
 ## Pages
 
 - [About]({{ site.url }}/about/): Author bio, career background, and site information.
 - [Blog Archive]({{ site.url }}/blog/): Full list of all blog posts.
-- [Tags]({{ site.url }}/tags/): Browse posts by topic tag.
+- [Notes]({{ site.url }}/notes/): Working notes on product thinking, frameworks, and ideas.
+- [Tags]({{ site.url }}/tags/): Browse posts and notes by topic tag.
 - [Podcasts]({{ site.url }}/podcasts/): Podcast episodes featuring Nir Yechiel.

--- a/notes/index.html
+++ b/notes/index.html
@@ -1,0 +1,39 @@
+---
+layout: page
+title: Notes
+description: "Working notes on product thinking, frameworks, and ideas - less polished than blog posts, shared openly."
+permalink: /notes/
+---
+
+<p class="note-disclaimer">
+  This is a collection of working notes on product thinking, frameworks, and ideas I find interesting. Think of it as a notebook I'm sharing openly.
+</p>
+
+{%- assign notes = site.notes | sort: "date" | reverse -%}
+{%- if notes.size > 0 -%}
+  <ul class="post-list">
+    {%- assign date_format = site.minima.date_format | default: "%b %-d, %Y" -%}
+    {%- for note in notes -%}
+    <li>
+      <span class="post-meta">{{ note.date | date: date_format }}</span>
+      <h3>
+        <a class="post-link" href="{{ note.url | relative_url }}">
+          {{ note.title | escape }}
+        </a>
+      </h3>
+      {%- if note.description -%}
+        <p>{{ note.description | escape }}</p>
+      {%- endif -%}
+      {%- if note.tags.size > 0 -%}
+        <ul class="post-tags">
+          {%- for tag in note.tags -%}
+            <li><a class="post-tag post-tag--link" href="{{ "/tags/" | relative_url }}#{{ tag | slugify }}">{{ tag | escape }}</a></li>
+          {%- endfor -%}
+        </ul>
+      {%- endif -%}
+    </li>
+    {%- endfor -%}
+  </ul>
+{%- else -%}
+  <p>No notes yet. Check back soon.</p>
+{%- endif -%}

--- a/search.json
+++ b/search.json
@@ -10,7 +10,19 @@ layout: null
     "date": {{ post.date | date: date_format | jsonify }},
     "tags": {{ post.tags | jsonify }},
     "excerpt": {{ post.excerpt | strip_html | strip_newlines | jsonify }},
-    "content": {{ post.content | strip_html | strip_newlines | jsonify }}
+    "content": {{ post.content | strip_html | strip_newlines | jsonify }},
+    "type": "post"
+  }{%- unless forloop.last and site.notes.size == 0 -%},{%- endunless -%}
+  {%- endfor -%}
+  {%- for note in site.notes -%}
+  {
+    "title": {{ note.title | jsonify }},
+    "url": {{ note.url | relative_url | jsonify }},
+    "date": {{ note.date | date: date_format | jsonify }},
+    "tags": {{ note.tags | jsonify }},
+    "excerpt": {{ note.description | default: note.excerpt | strip_html | strip_newlines | jsonify }},
+    "content": {{ note.content | strip_html | strip_newlines | jsonify }},
+    "type": "note"
   }{%- unless forloop.last -%},{%- endunless -%}
   {%- endfor -%}
 ]

--- a/tags.html
+++ b/tags.html
@@ -5,29 +5,70 @@ permalink: /tags/
 ---
 
 <div class="tags-page">
-  {%- assign sorted_tags = site.tags | sort -%}
+  {%- comment -%}Build a merged tag map from both posts and notes{%- endcomment -%}
+  {%- assign all_tags = "" | split: "" -%}
+  {%- for tag in site.tags -%}
+    {%- assign all_tags = all_tags | push: tag[0] -%}
+  {%- endfor -%}
+  {%- for note in site.notes -%}
+    {%- for tag in note.tags -%}
+      {%- unless all_tags contains tag -%}
+        {%- assign all_tags = all_tags | push: tag -%}
+      {%- endunless -%}
+    {%- endfor -%}
+  {%- endfor -%}
+  {%- assign all_tags = all_tags | sort_natural -%}
+
+  {%- comment -%}Tag cloud with combined counts{%- endcomment -%}
   <div class="tags-cloud">
     <a class="post-tag post-tag--link post-tag--all" href="#" data-show-all>All</a>
-    {%- for tag in sorted_tags -%}
-      <a class="post-tag post-tag--link" href="#{{ tag[0] | slugify }}">{{ tag[0] | escape }} <span class="tag-count">{{ tag[1].size }}</span></a>
+    {%- for tag_name in all_tags -%}
+      {%- assign post_count = site.tags[tag_name] | size | default: 0 -%}
+      {%- assign note_count = 0 -%}
+      {%- for note in site.notes -%}
+        {%- if note.tags contains tag_name -%}
+          {%- assign note_count = note_count | plus: 1 -%}
+        {%- endif -%}
+      {%- endfor -%}
+      {%- assign total_count = post_count | plus: note_count -%}
+      <a class="post-tag post-tag--link" href="#{{ tag_name | slugify }}">{{ tag_name | escape }} <span class="tag-count">{{ total_count }}</span></a>
     {%- endfor -%}
   </div>
 
-  {%- for tag in sorted_tags -%}
-    <div class="tag-group" id="{{ tag[0] | slugify }}">
-      <h2 class="tag-group-heading">{{ tag[0] | escape }}</h2>
+  {%- comment -%}Tag groups with posts and notes merged{%- endcomment -%}
+  {%- assign date_format = site.minima.date_format | default: "%b %-d, %Y" -%}
+  {%- for tag_name in all_tags -%}
+    {%- assign tagged_posts = "" | split: "" -%}
+    {%- if site.tags[tag_name] -%}
+      {%- assign tagged_posts = site.tags[tag_name] -%}
+    {%- endif -%}
+    {%- assign tagged_notes = "" | split: "" -%}
+    {%- for note in site.notes -%}
+      {%- if note.tags contains tag_name -%}
+        {%- assign tagged_notes = tagged_notes | push: note -%}
+      {%- endif -%}
+    {%- endfor -%}
+    {%- assign has_posts = tagged_posts | size -%}
+    {%- assign has_notes = tagged_notes | size -%}
+    {%- if has_posts > 0 or has_notes > 0 -%}
+    <div class="tag-group" id="{{ tag_name | slugify }}">
+      <h2 class="tag-group-heading">{{ tag_name | escape }}</h2>
+      {%- assign all_tagged = tagged_posts | concat: tagged_notes | sort: "date" | reverse -%}
       <ul class="post-list">
-        {%- assign date_format = site.minima.date_format | default: "%b %-d, %Y" -%}
-        {%- for post in tag[1] -%}
+        {%- for item in all_tagged -%}
           <li>
-            <span class="post-meta">{{ post.date | date: date_format }}</span>
+            <span class="post-meta">{{ item.date | date: date_format }}</span>
             <h3>
-              <a class="post-link" href="{{ post.url | relative_url }}">{{ post.title | escape }}</a>
+              <a class="post-link" href="{{ item.url | relative_url }}">{{ item.title | escape }}</a>
+              {%- if item.collection == "notes" -%}
+                <span class="note-badge">Note</span>
+              {%- endif -%}
             </h3>
           </li>
         {%- endfor -%}
       </ul>
     </div>
+    {%- endif -%}
   {%- endfor -%}
 </div>
 


### PR DESCRIPTION
## Summary

- Adds a new "Notes" section for shorter, less polished product thinking (frameworks, podcast takeaways, evolving ideas) - distinct from blog posts
- Notes use a Jekyll collection (`_notes/`) with their own simplified layout, index page with disclaimer, and `/notes/:title/` URLs
- Integrated into existing tag system (notes appear alongside posts in tag groups with a "Note" badge), search (Blog/Note pill labels in results), nav (active state highlighting), homepage ("Latest Notes" section), and `llms.txt`
- Notes are excluded from the RSS feed and follow.it subscription (intentional - subscribers opted into blog posts)
- Includes a placeholder note (`published: false`) so the section is ready when the first real note is written

## Key fixes in this PR

- **tags.html rendering bug**: `site.tags[tag_name] | default: "" | split: ""` corrupted post arrays by applying `split` to document objects, producing empty list items across all tag groups. Fixed with conditional assignment.
- **Unescaped `note.description`**: notes/index.html rendered description without `| escape`
- **Stale search message**: "No posts found" updated to "No results found" now that notes are searchable
- **Heading size inconsistency**: unified `.post-title` and `.page-heading` to 42px (minima base had 34px vs 44px)

## Test plan

- [ ] `/notes/` renders the index page with disclaimer text
- [ ] Nav "Notes" link highlights when viewing a note
- [ ] `/tags/` shows correct counts and renders all items (no empty list items)
- [ ] Search dropdown shows Blog/Note pill labels on results
- [ ] `/search/` page shows type badges on results
- [ ] Homepage hides "Latest Notes" when no published notes exist
- [ ] RSS feed (`/feed.xml`) does not contain `/notes/` URLs
- [ ] CI passes (4 new checks: notes index, RSS exclusion, layout, search.json type field)