### PR TITLE
Fix mobile menu sticking open and show reading time on short posts

### DIFF
--- a/_includes/header.html
+++ b/_includes/header.html
@@ -39,4 +39,5 @@
   </div>
 </header>
 
+<script>window.addEventListener('pageshow',function(){document.getElementById('nav-trigger').checked=false});</script>
 <script src="{{ '/assets/js/nav-search.js' | relative_url }}"></script>

--- a/_includes/read_time.html
+++ b/_includes/read_time.html
@@ -1,6 +1,8 @@
 {% capture words %}
 {{ content | number_of_words | minus: 180 }}
 {% endcapture %}
-{% unless words contains '-' %}
+{% if words contains '-' %}
+less than 1 min. read
+{% else %}
 {{ words | plus: 150 | divided_by: 150 | append: ' min. read' }}
-{% endunless %}
+{% endif %}


### PR DESCRIPTION
## Summary

- **Mobile menu stays open on back-navigation**: The hamburger menu uses a CSS checkbox hack that retains its checked state when the browser restores a page from bfcache. Added a `pageshow` event listener to uncheck `#nav-trigger` on every page show.
- **Missing reading time on short posts**: Posts under ~180 words (e.g. stub posts linking to external articles) showed no reading time at all. Now displays "less than 1 min. read" instead of hiding it.

## Test plan

- [ ] On mobile: open site, tap hamburger menu, navigate to a page, hit back - menu should be closed
- [ ] Check short posts show "less than 1 min. read" (e.g. [Red Hat OpenStack Platform 13: five things you need to know about networking](/blog/2018/07/15/red-hat-openstack-platform-13-five-things-you-need-to-know-about-networking/))
- [ ] Normal posts still show correct reading time (e.g. "12 min. read")