### PR TITLE
Fix mobile menu staying open on back-navigation

### DIFF
--- a/_includes/header.html
+++ b/_includes/header.html
@@ -40,5 +40,13 @@
   </div>
 </header>
 
-<script>window.addEventListener('pageshow',function(){document.getElementById('nav-trigger').checked=false});</script>
+<script>
+(function(){
+  var cb=document.getElementById('nav-trigger');
+  document.querySelectorAll('.site-nav .page-link').forEach(function(a){
+    a.addEventListener('click',function(){cb.checked=false});
+  });
+  window.addEventListener('pageshow',function(){setTimeout(function(){cb.checked=false},0)});
+})();
+</script>
 <script src="{{ '/assets/js/nav-search.js' | relative_url }}"></script>


### PR DESCRIPTION
## Summary

- Fix mobile hamburger menu staying open when navigating back via browser history on Chrome mobile
- Two-pronged approach: uncheck the nav-trigger checkbox on link click (before bfcache stores state) and defer the pageshow handler with setTimeout to run after Chrome restores form state

## Test plan

- [ ] On Chrome mobile (e.g. Pixel), open the hamburger menu, navigate to a page, press back - menu should be closed
- [ ] Verify menu still works normally (opens/closes on tap)
- [ ] Verify desktop nav is unaffected