### PR TITLE
Fix mobile menu staying open on back-navigation

### DIFF
--- a/_includes/header.html
+++ b/_includes/header.html
@@ -42,11 +42,14 @@
 
 <script>
 (function(){
+  var nav=document.querySelector('.site-nav');
   var cb=document.getElementById('nav-trigger');
-  document.querySelectorAll('.site-nav .page-link').forEach(function(a){
-    a.addEventListener('click',function(){cb.checked=false});
+  cb.addEventListener('change',function(){
+    nav.classList.toggle('nav-open',cb.checked);
   });
-  window.addEventListener('pageshow',function(){setTimeout(function(){cb.checked=false},0)});
+  document.querySelectorAll('.site-nav .page-link').forEach(function(a){
+    a.addEventListener('click',function(){nav.classList.remove('nav-open');cb.checked=false});
+  });
 })();
 </script>
 <script src="{{ '/assets/js/nav-search.js' | relative_url }}"></script>

--- a/assets/main.scss
+++ b/assets/main.scss
@@ -943,6 +943,15 @@ hr {
 // ————————————————————————————————————
 
 @include media-query($on-palm) {
+  .site-nav input:checked ~ .trigger {
+    display: none;
+  }
+
+  .site-nav.nav-open .trigger {
+    display: block;
+    padding-bottom: 5px;
+  }
+
   body {
     font-size: 16px;
   }


### PR DESCRIPTION
## Summary

- Replace minima's CSS checkbox hack with a JS-controlled class toggle for mobile menu visibility
- Browsers persist checkbox state through bfcache, causing the menu to reappear when navigating back. CSS classes are not persisted, so the menu always starts closed
- Previous attempts (PRs #157, #158) tried to uncheck the checkbox via JavaScript on `pageshow`, but Chrome mobile restores form state after all JS execution

## How it works

- CSS override: `input:checked ~ .trigger` is forced to `display: none` on mobile, so the checkbox can never show the menu
- New rule: `.site-nav.nav-open .trigger` controls visibility instead
- JS: checkbox `change` event toggles the `.nav-open` class; nav link clicks remove it
- Desktop nav is unaffected (overrides only apply inside mobile media query)

## Test plan

- [ ] On Chrome mobile: open hamburger menu, navigate to a page, press back - menu should be closed
- [ ] Menu opens/closes normally on tap
- [ ] Search inside the menu still works
- [ ] Desktop nav is unaffected