### PR TITLE
Fix mobile menu: use class toggle instead of checkbox

### DIFF
--- a/_includes/header.html
+++ b/_includes/header.html
@@ -8,7 +8,7 @@
     {%- if page_paths -%}
       <nav class="site-nav">
         <input type="checkbox" id="nav-trigger" class="nav-trigger" />
-        <label for="nav-trigger" aria-label="Menu">
+        <label for="nav-trigger" aria-label="Menu" aria-expanded="false">
           <span class="menu-icon">
             <svg viewBox="0 0 18 15" width="18px" height="15px">
               <path d="M18,1.484c0,0.82-0.665,1.484-1.484,1.484H1.484C0.665,2.969,0,2.304,0,1.484l0,0C0,0.665,0.665,0,1.484,0 h15.032C17.335,0,18,0.665,18,1.484L18,1.484z M18,7.516C18,8.335,17.335,9,16.516,9H1.484C0.665,9,0,8.335,0,7.516l0,0 c0-0.82,0.665-1.484,1.484-1.484h15.032C17.335,6.031,18,6.696,18,7.516L18,7.516z M18,13.516C18,14.335,17.335,15,16.516,15H1.484 C0.665,15,0,14.335,0,13.516l0,0c0-0.82,0.665-1.483,1.484-1.483h15.032C17.335,12.031,18,12.695,18,13.516L18,13.516z"/>
@@ -44,13 +44,16 @@
 (function(){
   var nav=document.querySelector('.site-nav');
   var label=document.querySelector('label[for="nav-trigger"]');
+  function close(){nav.classList.remove('nav-open');label.setAttribute('aria-expanded','false')}
   label.addEventListener('click',function(e){
     e.preventDefault();
-    nav.classList.toggle('nav-open');
+    var open=nav.classList.toggle('nav-open');
+    label.setAttribute('aria-expanded',String(open));
   });
   document.querySelectorAll('.site-nav .page-link').forEach(function(a){
-    a.addEventListener('click',function(){nav.classList.remove('nav-open')});
+    a.addEventListener('click',close);
   });
+  window.addEventListener('pageshow',function(){close()});
 })();
 </script>
 <script src="{{ '/assets/js/nav-search.js' | relative_url }}"></script>

--- a/_includes/header.html
+++ b/_includes/header.html
@@ -43,12 +43,13 @@
 <script>
 (function(){
   var nav=document.querySelector('.site-nav');
-  var cb=document.getElementById('nav-trigger');
-  cb.addEventListener('change',function(){
-    nav.classList.toggle('nav-open',cb.checked);
+  var label=document.querySelector('label[for="nav-trigger"]');
+  label.addEventListener('click',function(e){
+    e.preventDefault();
+    nav.classList.toggle('nav-open');
   });
   document.querySelectorAll('.site-nav .page-link').forEach(function(a){
-    a.addEventListener('click',function(){nav.classList.remove('nav-open');cb.checked=false});
+    a.addEventListener('click',function(){nav.classList.remove('nav-open')});
   });
 })();
 </script>

--- a/assets/main.scss
+++ b/assets/main.scss
@@ -943,10 +943,6 @@ hr {
 // ————————————————————————————————————
 
 @include media-query($on-palm) {
-  .site-nav input:checked ~ .trigger {
-    display: none;
-  }
-
   .site-nav.nav-open .trigger {
     display: block;
     padding-bottom: 5px;


### PR DESCRIPTION
## Summary

- Fix broken hamburger menu from PR #159 - the `input:checked` override had higher CSS specificity than `.nav-open`, so the menu could never open
- Intercept label click with `preventDefault()` so the checkbox is never toggled
- Only the `.nav-open` CSS class controls menu visibility; CSS classes are not persisted through bfcache, so the menu always starts closed after back-navigation

## How it works

1. Label click: `preventDefault()` stops checkbox toggle, JS toggles `.nav-open` class
2. Nav link click: JS removes `.nav-open` class
3. Back-navigation (bfcache): checkbox was never checked, `.nav-open` class not persisted - menu is closed
4. Without JS (graceful degradation): label click toggles checkbox as usual, minima's original CSS works

## Test plan

- [ ] On Chrome mobile: hamburger menu opens and closes on tap
- [ ] Navigate to a page via menu, press back - menu should be closed
- [ ] Search inside the menu works
- [ ] Desktop nav unaffected