### PR TITLE
Fix mobile menu showing on back-navigation

### DIFF
--- a/_includes/header.html
+++ b/_includes/header.html
@@ -43,8 +43,9 @@
 <script>
 (function(){
   var nav=document.querySelector('.site-nav');
+  var cb=document.getElementById('nav-trigger');
   var label=document.querySelector('label[for="nav-trigger"]');
-  function close(){nav.classList.remove('nav-open');label.setAttribute('aria-expanded','false')}
+  function close(){cb.checked=false;nav.classList.remove('nav-open');label.setAttribute('aria-expanded','false')}
   label.addEventListener('click',function(e){
     e.preventDefault();
     var open=nav.classList.toggle('nav-open');

--- a/assets/main.scss
+++ b/assets/main.scss
@@ -943,7 +943,16 @@ hr {
 // ————————————————————————————————————
 
 @include media-query($on-palm) {
-  .site-nav.nav-open .trigger {
+  // Neutralize minima's checkbox hack - browser back-navigation restores
+  // checkbox state, which makes the menu appear via input:checked ~ .trigger.
+  // This rule has the same specificity (0,3,1) and wins by source order.
+  .site-nav input:checked ~ .trigger {
+    display: none;
+  }
+
+  // JS-controlled class shows the menu. The input~ combinator matches
+  // specificity with the rule above so this wins by source order when both apply.
+  .site-nav.nav-open input ~ .trigger {
     display: block;
     padding-bottom: 5px;
   }


### PR DESCRIPTION
## Summary

- Override minima's `input:checked ~ .trigger { display: block }` with a same-specificity `display: none` rule that wins by source order - this prevents the browser's form state restoration from making the menu visible on back-navigation
- Bump the `.nav-open` show rule from `.site-nav.nav-open .trigger` (specificity 0,3,0) to `.site-nav.nav-open input ~ .trigger` (specificity 0,3,1) so it beats the override when the menu should actually be open
- Also explicitly uncheck the checkbox in the `close()` function as a belt-and-suspenders measure

The root cause: browsers restore checkbox state on back-navigation (bfcache or form state restoration). Minima's CSS checkbox hack uses `input:checked ~ .trigger` to show/hide the mobile nav. Even though our JS uses `preventDefault` on the label click (so the checkbox is never checked by user interaction), the browser's own state restoration re-checks it, triggering minima's CSS rule. Previous fix attempts used only JS-based approaches (pageshow handlers, setTimeout, click handlers) which all failed because the CSS rule fires before JS can intervene.

This fix works at the CSS level - even if the checkbox is restored to checked, the menu stays hidden unless the `.nav-open` class is also present (which is only added by our JS click handler, never by browser state restoration).

## Test plan

1. On Chrome mobile (or mobile emulation): open hamburger menu, tap a nav link, press back - menu should be closed
2. Verify hamburger menu still opens and closes normally on mobile
3. Verify desktop nav is unaffected (rules are inside mobile media query)