### PR TITLE
Fix mobile menu: revert CSS specificity approach, use setTimeout for bfcache

### DIFF
--- a/_includes/header.html
+++ b/_includes/header.html
@@ -54,7 +54,7 @@
   document.querySelectorAll('.site-nav .page-link').forEach(function(a){
     a.addEventListener('click',close);
   });
-  window.addEventListener('pageshow',function(){close()});
+  window.addEventListener('pageshow',function(e){close();if(e.persisted)setTimeout(close,0)});
 })();
 </script>
 <script src="{{ '/assets/js/nav-search.js' | relative_url }}"></script>

--- a/assets/main.scss
+++ b/assets/main.scss
@@ -943,16 +943,7 @@ hr {
 // ————————————————————————————————————
 
 @include media-query($on-palm) {
-  // Neutralize minima's checkbox hack - browser back-navigation restores
-  // checkbox state, which makes the menu appear via input:checked ~ .trigger.
-  // This rule has the same specificity (0,3,1) and wins by source order.
-  .site-nav input:checked ~ .trigger {
-    display: none;
-  }
-
-  // JS-controlled class shows the menu. The input~ combinator matches
-  // specificity with the rule above so this wins by source order when both apply.
-  .site-nav.nav-open input ~ .trigger {
+  .site-nav.nav-open .trigger {
     display: block;
     padding-bottom: 5px;
   }


### PR DESCRIPTION
## Summary

- Revert PR #161's `input ~` CSS selectors which broke menu opening
- Keep simple `.site-nav.nav-open .trigger` class toggle (from PR #160)
- Keep `cb.checked=false` in `close()` (from PR #161) to uncheck the checkbox on every close
- Add `setTimeout(close, 0)` on `pageshow` when `e.persisted` is true (bfcache restore) to catch browsers that restore checkbox state after the event fires

## How it works

1. Label click: `preventDefault()` stops checkbox toggle, JS toggles `.nav-open` class
2. Nav link click: `close()` removes `.nav-open` and unchecks checkbox
3. Back-navigation (bfcache): `pageshow` fires with `e.persisted=true`, `close()` runs immediately and again after a microtask to catch late form state restoration

## Test plan

- [ ] On Chrome mobile: hamburger menu opens and closes on tap
- [ ] Navigate to a page via menu, press back - menu should be closed
- [ ] Search inside the menu works
- [ ] Desktop nav unaffected